### PR TITLE
feat: add tendermint client and parse block RPC API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 !.vscode/launch.json
 !.vscode/extensions.json
 *.code-workspace
+.idea/*
 
 # Local History for Visual Studio Code
 .history/

--- a/adapter/tendermint/client.go
+++ b/adapter/tendermint/client.go
@@ -1,0 +1,7 @@
+package tendermint
+
+import "github.com/crypto-com/chainindex/adapter/tendermint/types"
+
+type Client interface {
+	Block(height uint64) (*types.Block, error)
+}

--- a/adapter/tendermint/types/block.go
+++ b/adapter/tendermint/types/block.go
@@ -1,0 +1,129 @@
+package types
+
+import "time"
+
+// BlockResp defines the structure for tendermint /block API response JSON
+type BlockResp struct {
+	Jsonrpc string `json:"jsonrpc"`
+	ID      int    `json:"id"`
+	Result  struct {
+		BlockID struct {
+			Hash  string `json:"hash"`
+			Parts struct {
+				Total int    `json:"total"`
+				Hash  string `json:"hash"`
+			} `json:"parts"`
+		} `json:"block_id"`
+		Block struct {
+			Header struct {
+				Version struct {
+					Block string `json:"block"`
+				} `json:"version"`
+				ChainID     string    `json:"chain_id"`
+				Height      string    `json:"height"`
+				Time        time.Time `json:"time"`
+				LastBlockID struct {
+					Hash  string `json:"hash"`
+					Parts struct {
+						Total int    `json:"total"`
+						Hash  string `json:"hash"`
+					} `json:"parts"`
+				} `json:"last_block_id"`
+				LastCommitHash     string `json:"last_commit_hash"`
+				DataHash           string `json:"data_hash"`
+				ValidatorsHash     string `json:"validators_hash"`
+				NextValidatorsHash string `json:"next_validators_hash"`
+				ConsensusHash      string `json:"consensus_hash"`
+				AppHash            string `json:"app_hash"`
+				LastResultsHash    string `json:"last_results_hash"`
+				EvidenceHash       string `json:"evidence_hash"`
+				ProposerAddress    string `json:"proposer_address"`
+			} `json:"header"`
+			Data struct {
+				Txs []string `json:"txs"`
+			} `json:"data"`
+			Evidence struct {
+				Evidence []struct {
+					Type  string `json:"type"`
+					Value struct {
+						PubKey struct {
+							Type  string `json:"type"`
+							Value string `json:"value"`
+						} `json:"PubKey"`
+						VoteA struct {
+							Type    int    `json:"type"`
+							Height  string `json:"height"`
+							Round   int    `json:"round"`
+							BlockID struct {
+								Hash  string `json:"hash"`
+								Parts struct {
+									Total int    `json:"total"`
+									Hash  string `json:"hash"`
+								} `json:"parts"`
+							} `json:"block_id"`
+							Timestamp        time.Time `json:"timestamp"`
+							ValidatorAddress string    `json:"validator_address"`
+							ValidatorIndex   string    `json:"validator_index"`
+							Signature        string    `json:"signature"`
+						} `json:"VoteA"`
+						VoteB struct {
+							Type    int    `json:"type"`
+							Height  string `json:"height"`
+							Round   int    `json:"round"`
+							BlockID struct {
+								Hash  string `json:"hash"`
+								Parts struct {
+									Total int    `json:"total"`
+									Hash  string `json:"hash"`
+								} `json:"parts"`
+							} `json:"block_id"`
+							Timestamp        time.Time `json:"timestamp"`
+							ValidatorAddress string    `json:"validator_address"`
+							ValidatorIndex   string    `json:"validator_index"`
+							Signature        string    `json:"signature"`
+						} `json:"VoteB"`
+					} `json:"value"`
+				} `json:"evidence"`
+			} `json:"evidence"`
+			LastCommit struct {
+				Height  string `json:"height"`
+				Round   int    `json:"round"`
+				BlockID struct {
+					Hash  string `json:"hash"`
+					Parts struct {
+						Total int    `json:"total"`
+						Hash  string `json:"hash"`
+					} `json:"parts"`
+				} `json:"block_id"`
+				Signatures []RawBlockSignature `json:"signatures"`
+			} `json:"last_commit"`
+		} `json:"block"`
+	} `json:"result"`
+}
+
+// RawBlockSignature defines the structure for signatures in /block API
+type RawBlockSignature struct {
+	BlockIDFlag      int       `json:"block_id_flag"`
+	ValidatorAddress string    `json:"validator_address"`
+	Timestamp        time.Time `json:"timestamp"`
+	Signature        *string   `json:"signature"`
+}
+
+// BlockSignature defines the parsed signatures
+type BlockSignature struct {
+	BlockIDFlag      int
+	ValidatorAddress string
+	Timestamp        time.Time
+	Signature        string
+}
+
+// Block defines parsed block data
+type Block struct {
+	Height          uint64
+	Hash            string
+	Time            time.Time
+	AppHash         string
+	ProposerAddress string
+	Txs             []string
+	Signatures      []BlockSignature
+}

--- a/go.sum
+++ b/go.sum
@@ -117,6 +117,7 @@ github.com/golang/protobuf v1.4.0-rc.2/go.mod h1:LlEzMj4AhA7rCAGe4KMBDvJI+AwstrU
 github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0/go.mod h1:WU3c8KckQ9AFe+yFwt9sWVRKCVIyN9cPHBJSNnbL67w=
 github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvqG2KuDX0=
 github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QDs8UjoX8=
+github.com/golang/protobuf v1.4.2 h1:+Z5KGCizgyZCbGh1KZqA0fcLLkwbsjIzS4aV2v7wJX0=
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/snappy v0.0.0-20170215233205-553a64147049/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
@@ -588,6 +589,7 @@ google.golang.org/protobuf v1.22.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=
+google.golang.org/protobuf v1.25.0 h1:Ejskq+SyPohKW+1uil0JJMtmHCgJPJ/qWTxr8qp+R4c=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/infrastructure/tendermint/httpclient.go
+++ b/infrastructure/tendermint/httpclient.go
@@ -1,0 +1,115 @@
+package tendermint
+
+import (
+	"fmt"
+	"github.com/crypto-com/chainindex/adapter/tendermint/types"
+	jsoniter "github.com/json-iterator/go"
+	"io"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+type HTTPClient struct {
+	httpClient       *http.Client
+	tendermintRPCUrl string
+}
+
+// NewHTTPClient returns a new HTTPClient for tendermint request
+func NewHTTPClient(tendermintRPCUrl string) *HTTPClient {
+	httpClient := &http.Client{
+		Timeout: 10 * time.Second,
+	}
+
+	return &HTTPClient{
+		httpClient,
+		tendermintRPCUrl,
+	}
+}
+
+// Block gets the block response with target height
+func (client *HTTPClient) Block(height uint64) (*types.Block, error) {
+	var err error
+
+	rawRespBody, err := client.request("block", "height="+strconv.FormatUint(height, 10))
+	if err != nil {
+		return nil, err
+	}
+	defer rawRespBody.Close()
+
+	block, err := client.parseBlockResp(rawRespBody)
+	if err != nil {
+		return nil, err
+	}
+
+	return block, nil
+}
+
+// parseBlockSignatures parses the BlockResp into Block type
+func (client *HTTPClient) parseBlockResp(rawRespReader io.Reader) (*types.Block, error) {
+	var err error
+
+	var resp types.BlockResp
+	if err = jsoniter.NewDecoder(rawRespReader).Decode(&resp); err != nil {
+		return nil, fmt.Errorf("error decoding Tendermint block response: %v", err)
+	}
+
+	height, err := strconv.ParseUint(resp.Result.Block.Header.Height, 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("error converting block height to unsigned integer: %v", err)
+	}
+
+	return &types.Block{
+		Height:          height,
+		Hash:            resp.Result.BlockID.Hash,
+		Time:            resp.Result.Block.Header.Time,
+		AppHash:         resp.Result.Block.Header.AppHash,
+		ProposerAddress: resp.Result.Block.Header.ProposerAddress,
+		Txs:             resp.Result.Block.Data.Txs,
+		Signatures:      client.parseBlockSignatures(resp.Result.Block.LastCommit.Signatures),
+	}, nil
+}
+
+// parseBlockSignatures parses the rawSignatures in JSON response into BlockSignature type
+func (client *HTTPClient) parseBlockSignatures(rawSignatures []types.RawBlockSignature) []types.BlockSignature {
+	if rawSignatures == nil {
+		return nil
+	}
+
+	signatures := make([]types.BlockSignature, 0, len(rawSignatures))
+	for _, rawSignature := range rawSignatures {
+		if rawSignature.Signature == nil {
+			continue
+		}
+		signatures = append(signatures, types.BlockSignature{
+			BlockIDFlag:      rawSignature.BlockIDFlag,
+			ValidatorAddress: rawSignature.ValidatorAddress,
+			Timestamp:        rawSignature.Timestamp,
+			Signature:        *rawSignature.Signature,
+		})
+	}
+
+	return signatures
+}
+
+// request construct tendermint url and issues an HTTP request
+// returns the success http Body
+func (client *HTTPClient) request(method string, queryString ...string) (io.ReadCloser, error) {
+	var err error
+
+	url := client.tendermintRPCUrl + "/" + method
+	if len(queryString) > 0 {
+		url += "?" + queryString[0]
+	}
+	rawResp, err := client.httpClient.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("error requesting Tendermint %s endpoint: %v", url, err)
+	}
+
+	if rawResp.StatusCode != 200 {
+		rawResp.Body.Close()
+		return nil, fmt.Errorf("error requesting Tendermint %s endpoint: %s", method, rawResp.Status)
+	}
+
+	return rawResp.Body, nil
+}

--- a/infrastructure/tendermint/httpclient_test.go
+++ b/infrastructure/tendermint/httpclient_test.go
@@ -1,0 +1,154 @@
+package tendermint_test
+
+import (
+	tendermintadapter "github.com/crypto-com/chainindex/adapter/tendermint"
+	"github.com/crypto-com/chainindex/adapter/tendermint/types"
+	"github.com/crypto-com/chainindex/infrastructure/tendermint"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"net/http"
+	"time"
+
+	"github.com/onsi/gomega/ghttp"
+)
+
+var _ = Describe("HTTPClient", func() {
+	var server *ghttp.Server
+
+	BeforeEach(func() {
+		server = ghttp.NewServer()
+	})
+
+	It("should implement Client", func() {
+		var _ tendermintadapter.Client = tendermint.NewHTTPClient("http://localhost:26657")
+	})
+
+	Describe("Block", func() {
+		It("should return block response", func() {
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/block", "height=100"),
+					ghttp.RespondWith(http.StatusOK, BLOCK_JSON),
+				),
+			)
+
+			blockHeight := uint64(100)
+			client := tendermint.NewHTTPClient(server.URL())
+			block, err := client.Block(blockHeight)
+			Expect(err).To(BeNil())
+			blockTime, _ := time.Parse("2006-01-02T15:04:05.000000000Z", "2020-10-15T09:33:42.195143319Z")
+			signature0Time, _ := time.Parse("2006-01-02T15:04:05.00000000Z", "2020-10-15T09:33:42.18646236Z")
+			signature1Time, _ := time.Parse("2006-01-02T15:04:05.000000000Z", "2020-10-15T09:33:42.195143319Z")
+			signature2Time, _ := time.Parse("2006-01-02T15:04:05.000000000Z", "2020-10-15T09:33:42.206633743Z")
+
+			Expect(*block).To(Equal(types.Block{
+				Height:          blockHeight,
+				Hash:            "82C25937191D1CF73BE9222CB04CE35B7A1366CC5BB08D9BB9AB457712E4F2D1",
+				Time:            blockTime,
+				AppHash:         "6AE0920938F76727054BC2531247632C5C0521E2B91EA3A9864EA4FF55023D77",
+				ProposerAddress: "384E5F30F02538C0A34CBFF32F8D5554671C9029",
+				Txs:             []string{},
+				Signatures: []types.BlockSignature{
+					{
+						BlockIDFlag:      2,
+						ValidatorAddress: "384E5F30F02538C0A34CBFF32F8D5554671C9029",
+						Timestamp:        signature0Time,
+						Signature:        "Lnjz+jTGTk6DzqvbvdjFIG5zyzzpioiN37/B2pKi6ac/Kf2a+kmfeQA3CXnPO5GY/AoImfbVcCQs4asTSDCqCA==",
+					},
+					{
+						BlockIDFlag:      2,
+						ValidatorAddress: "4D9F47C5A19D5550685D2D55DF2FF8C5D7504CEB",
+						Timestamp:        signature1Time,
+						Signature:        "OpYxiF7QTAaG4NG2/iHWvts8ISQED6F+pNU5Cv2ts8c8mFW9J+g0oig3IXhvVG011uQjcr0CVw5P0eOXx1vYDg==",
+					},
+					{
+						BlockIDFlag:      2,
+						ValidatorAddress: "6D9E4B4995037D608E365CE90436C24580ABCC33",
+						Timestamp:        signature2Time,
+						Signature:        "jQd4JNrvX6DKmqDZ9VqoKtxRIxQHrvPWd4XW+ayrtVakiIMCWoVf1GMvxLbXYg68CyjmbuAX2VhCD0gSnj3pAw==",
+					},
+				},
+			}))
+		})
+	})
+})
+
+const (
+	BLOCK_JSON = `
+{
+  "jsonrpc": "2.0",
+  "id": -1,
+  "result": {
+    "block_id": {
+      "hash": "82C25937191D1CF73BE9222CB04CE35B7A1366CC5BB08D9BB9AB457712E4F2D1",
+      "parts": {
+        "total": 1,
+        "hash": "0A19FD939EBCE493C3126D99A6133F968AF454CAAEEAA1AD20EC4A3CFD60F2D5"
+      }
+    },
+    "block": {
+      "header": {
+        "version": {
+          "block": "11"
+        },
+        "chain_id": "testnet-croeseid-1",
+        "height": "100",
+        "time": "2020-10-15T09:33:42.195143319Z",
+        "last_block_id": {
+          "hash": "1532E4FFBDE4FE8CCDF5654A097D534B8C6E2EBC4473F36CFE314C0421970C2E",
+          "parts": {
+            "total": 1,
+            "hash": "EEDFCCF098B1695CE939CF4E395AA8FC0EEC9F4673E1418B29E8928489BEF06A"
+          }
+        },
+        "last_commit_hash": "E7437018C93A3BEA020C76DF06A209BFD9E2EEB6F01A5D4AF1EC64BA6488E6F5",
+        "data_hash": "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
+        "validators_hash": "C97D9876B52DAD0DA395EA0203EF1D85682198E82AB90D2CE60DB1FB25117C12",
+        "next_validators_hash": "C97D9876B52DAD0DA395EA0203EF1D85682198E82AB90D2CE60DB1FB25117C12",
+        "consensus_hash": "048091BC7DDC283F77BFBF91D73C44DA58C3DF8A9CBC867405D8B7F3DAADA22F",
+        "app_hash": "6AE0920938F76727054BC2531247632C5C0521E2B91EA3A9864EA4FF55023D77",
+        "last_results_hash": "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
+        "evidence_hash": "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
+        "proposer_address": "384E5F30F02538C0A34CBFF32F8D5554671C9029"
+      },
+      "data": {
+        "txs": []
+      },
+      "evidence": {
+        "evidence": []
+      },
+      "last_commit": {
+        "height": "99",
+        "round": 0,
+        "block_id": {
+          "hash": "1532E4FFBDE4FE8CCDF5654A097D534B8C6E2EBC4473F36CFE314C0421970C2E",
+          "parts": {
+            "total": 1,
+            "hash": "EEDFCCF098B1695CE939CF4E395AA8FC0EEC9F4673E1418B29E8928489BEF06A"
+          }
+        },
+        "signatures": [
+          {
+            "block_id_flag": 2,
+            "validator_address": "384E5F30F02538C0A34CBFF32F8D5554671C9029",
+            "timestamp": "2020-10-15T09:33:42.18646236Z",
+            "signature": "Lnjz+jTGTk6DzqvbvdjFIG5zyzzpioiN37/B2pKi6ac/Kf2a+kmfeQA3CXnPO5GY/AoImfbVcCQs4asTSDCqCA=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "4D9F47C5A19D5550685D2D55DF2FF8C5D7504CEB",
+            "timestamp": "2020-10-15T09:33:42.195143319Z",
+            "signature": "OpYxiF7QTAaG4NG2/iHWvts8ISQED6F+pNU5Cv2ts8c8mFW9J+g0oig3IXhvVG011uQjcr0CVw5P0eOXx1vYDg=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "6D9E4B4995037D608E365CE90436C24580ABCC33",
+            "timestamp": "2020-10-15T09:33:42.206633743Z",
+            "signature": "jQd4JNrvX6DKmqDZ9VqoKtxRIxQHrvPWd4XW+ayrtVakiIMCWoVf1GMvxLbXYg68CyjmbuAX2VhCD0gSnj3pAw=="
+          }
+        ]
+      }
+    }
+  }
+}`
+)

--- a/infrastructure/tendermint/tendermint_suite_test.go
+++ b/infrastructure/tendermint/tendermint_suite_test.go
@@ -1,0 +1,13 @@
+package tendermint_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestTendermint(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Tendermint Suite")
+}


### PR DESCRIPTION
- Add tendermint http client and get /block response as an example
- Add parse block function
- Add block related types: BlockResp and Block, etc
- Add unit tests for the client

Resolve #12 