### PR TITLE
feat: add command structure and CreateBlock command as an example

### DIFF
--- a/appinterface/command/blockcommands.go
+++ b/appinterface/command/blockcommands.go
@@ -1,0 +1,62 @@
+package command
+
+import (
+	"fmt"
+	tenderminttypes "github.com/crypto-com/chainindex/adapter/tendermint/types"
+	"github.com/crypto-com/chainindex/appinterface/command/types"
+	"github.com/crypto-com/chainindex/appinterface/event"
+)
+
+// CreateBlockCommand
+type CreateBlockCommand struct {
+	Command
+	Payload *types.Block
+}
+
+// NewCreateBlockCommand create a CreateBlockCommand
+func NewCreateBlockCommand(Payload *types.Block) CreateBlockCommand {
+	cmd := NewCommand("CreateBlock", 1)
+	return CreateBlockCommand{
+		cmd,
+		Payload,
+	}
+}
+
+// Exec creates an event
+func (c *CreateBlockCommand) Exec() (*event.Event, error) {
+	var err error
+	if c.Payload == nil {
+		return nil, fmt.Errorf("cannot create event with empty command payload: %v", err)
+	}
+
+	// create new event
+	evt := event.NewEvent("BlockCreated", c.Version, c.Payload)
+	return &evt, nil
+}
+
+// CreateRawBlockCommand
+type CreateRawBlockCommand struct {
+	Command
+	Payload *tenderminttypes.BlockResp
+}
+
+// NewCreateRawBlockCommand create a CreateRawBlockCommand
+func NewCreateRawBlockCommand(Payload *tenderminttypes.BlockResp) CreateRawBlockCommand {
+	cmd := NewCommand("CreateRawBlock", 1)
+	return CreateRawBlockCommand{
+		cmd,
+		Payload,
+	}
+}
+
+// Exec create an event
+func (c *CreateRawBlockCommand) Exec() (*event.Event, error) {
+	var err error
+	if c.Payload == nil {
+		return nil, fmt.Errorf("cannot create event with empty command payload: %v", err)
+	}
+
+	// create new event
+	evt := event.NewEvent("RawBlockCreated", c.Version, c.Payload)
+	return &evt, nil
+}

--- a/appinterface/command/command.go
+++ b/appinterface/command/command.go
@@ -1,0 +1,33 @@
+package command
+
+// Command interface provides a generic signature which any other
+// type can implement
+type CommandAdapter interface {
+	Exec() error
+	GetType() string
+	GetVersion() uint64
+}
+
+// command struct defines the fields that a command needs
+type Command struct {
+	Type    string
+	Version uint64
+}
+
+// NewCommand creates a new Command
+func NewCommand(Type string, Version uint64) Command {
+	return Command{
+		Type,
+		Version,
+	}
+}
+
+// GetType return the type of a command
+func (c Command) GetType() string {
+	return c.Type
+}
+
+// GetVersion return the version of a command
+func (c Command) GetVersion() uint64 {
+	return c.Version
+}

--- a/appinterface/command/executor/executor.go
+++ b/appinterface/command/executor/executor.go
@@ -1,0 +1,11 @@
+package executor
+
+// Executor interface defines command executor signature
+type Executor interface {
+	Exec() error
+	ExecAll() error
+}
+
+// Exec process the command to event and save
+//func Exec(c command.Command) error {}
+

--- a/appinterface/command/types/block.go
+++ b/appinterface/command/types/block.go
@@ -1,0 +1,23 @@
+// Current file defines all block command types' Payload
+package types
+
+import "time"
+
+// BlockSignature defines the parsed signatures
+type BlockSignature struct {
+	BlockIDFlag      int
+	ValidatorAddress string
+	Timestamp        time.Time
+	Signature        string
+}
+
+// Block defines CreateBlock cmd payload
+type Block struct {
+	Height          uint64
+	Hash            string
+	Time            time.Time
+	AppHash         string
+	ProposerAddress string
+	Txs             []string
+	Signatures      []BlockSignature
+}

--- a/appinterface/event/event.go
+++ b/appinterface/event/event.go
@@ -1,0 +1,23 @@
+package event
+
+type Event struct {
+	Name    string
+	Version uint64
+	Payload interface{}
+}
+
+// NewEvent creates a new event
+func NewEvent(Name string, Version uint64, Payload interface{}) Event {
+	return Event{
+		Name,
+		Version,
+		Payload,
+	}
+}
+
+// Store function will run store current event
+func (evt Event) Store() error {
+	// TODO: store the event and get ready for rollback this event store procedure
+	// if a sequence of event storing failed in the middle
+	return nil
+}


### PR DESCRIPTION
Current thoughts refer to [resovle](https://reimagined.github.io/resolve/docs/write-side#aggregate-command-handlers), `Command` provides basic signatures. For each command like `CreateBlockCommand`, it has its own `type`, interface and its own Payload struct to match. Then `Exec` will process the payload, create event and save the event.