### PR TITLE
Problem: Missing block count and transaction count APIs

### DIFF
--- a/appinterface/projection/view/transactions.go
+++ b/appinterface/projection/view/transactions.go
@@ -181,6 +181,23 @@ func (view *Transactions) List(
 	return transactions, paginationResult, nil
 }
 
+func (view *Transactions) Count() (int, error) {
+	sql, _, err := view.rdb.StmtBuilder.Select("COUNT(1)").From(
+		"view_transactions",
+	).ToSql()
+	if err != nil {
+		return 0, fmt.Errorf("error building transactions count selection sql: %v", err)
+	}
+
+	result := view.rdb.QueryRow(sql)
+	var count int
+	if err := result.Scan(&count); err != nil {
+		return 0, fmt.Errorf("error scanning transactions count selection query: %v", err)
+	}
+
+	return count, nil
+}
+
 type Transaction struct {
 	BlockHeight   int64                `json:"blockHeight"`
 	BlockHash     string               `json:"blockHash"`

--- a/cmd/chainindex/httpapiserver.go
+++ b/cmd/chainindex/httpapiserver.go
@@ -38,8 +38,9 @@ func (server *HTTPAPIServer) Run() error {
 	)
 
 	blocksHandler := handlers.NewBlocks(server.logger, server.rdbConn.ToHandle())
+	statusHandler := handlers.NewStatusHandler(server.logger, server.rdbConn.ToHandle())
 	transactionsHandler := handlers.NewTransactions(server.logger, server.rdbConn.ToHandle())
-	routeRegistry := routes.NewRoutesRegistry(blocksHandler, transactionsHandler)
+	routeRegistry := routes.NewRoutesRegistry(blocksHandler, statusHandler, transactionsHandler)
 	routeRegistry.Register(httpServer)
 
 	server.logger.Infof("server start listening on: %s", server.listeningAddress)

--- a/infrastructure/httpapi/handlers/status.go
+++ b/infrastructure/httpapi/handlers/status.go
@@ -1,0 +1,58 @@
+package handlers
+
+import (
+	"github.com/crypto-com/chainindex/appinterface/projection/view"
+	"github.com/crypto-com/chainindex/appinterface/rdb"
+	"github.com/crypto-com/chainindex/infrastructure/httpapi"
+	applogger "github.com/crypto-com/chainindex/internal/logger"
+	"github.com/valyala/fasthttp"
+)
+
+type StatusHandler struct {
+	logger applogger.Logger
+
+	blocksView       *view.Blocks
+	transactionsView *view.Transactions
+}
+
+func NewStatusHandler(logger applogger.Logger, rdbHandle *rdb.Handle) *StatusHandler {
+	return &StatusHandler{
+		logger.WithFields(applogger.LogFields{
+			"module": "StatusHandler",
+		}),
+
+		view.NewBlocks(rdbHandle),
+		view.NewTransactions(rdbHandle),
+	}
+}
+
+func (handler *StatusHandler) GetStatus(ctx *fasthttp.RequestCtx) {
+	blockCount, err := handler.blocksView.Count()
+
+	if err != nil {
+		handler.logger.Errorf("error fetching block count: %v", err)
+		httpapi.InternalServerError(ctx)
+		return
+	}
+
+	transactionCount, err := handler.transactionsView.Count()
+
+	if err != nil {
+		handler.logger.Errorf("error fetching transaction count: %v", err)
+		httpapi.InternalServerError(ctx)
+		return
+	}
+
+	status := Status{
+		BlockCount:       blockCount,
+		TransactionCount: transactionCount,
+	}
+
+	httpapi.Success(ctx, status)
+}
+
+type Status struct {
+	BlockCount       int `json:"blockCount"`
+	TransactionCount int `json:"transactionCount"`
+	// TODO: Add more items when available in projections
+}

--- a/infrastructure/httpapi/routes/routes.go
+++ b/infrastructure/httpapi/routes/routes.go
@@ -8,15 +8,18 @@ import (
 
 type RouteRegistry struct {
 	blocksHandler      *handlers.Blocks
+	statusHandler      *handlers.StatusHandler
 	transactionHandler *handlers.Transactions
 }
 
 func NewRoutesRegistry(
 	blocksHandler *handlers.Blocks,
+	statusHandler *handlers.StatusHandler,
 	transactionHandler *handlers.Transactions,
 ) *RouteRegistry {
 	return &RouteRegistry{
 		blocksHandler,
+		statusHandler,
 		transactionHandler,
 	}
 }
@@ -28,5 +31,6 @@ func (registry *RouteRegistry) Register(server *httpapi.Server) {
 	})
 	server.GET("/api/v1/blocks", registry.blocksHandler.List)
 	server.GET("/api/v1/blocks/{height}/transactions", registry.blocksHandler.ListTransactionsByHeight)
+	server.GET("/api/v1/status", registry.statusHandler.GetStatus)
 	server.GET("/api/v1/transactions", registry.transactionHandler.List)
 }


### PR DESCRIPTION
Solution: Added `status` API to return block count and transaction count. More items can be added as required in `status` API. Fixes #119.