### PR TITLE
Problem (wip #167): more space efficient column types are not used

### DIFF
--- a/migrations/20201201180628_event-enum.down.sql
+++ b/migrations/20201201180628_event-enum.down.sql
@@ -1,0 +1,3 @@
+alter table events
+    alter column name type varchar;
+drop type event_name;

--- a/migrations/20201201180628_event-enum.up.sql
+++ b/migrations/20201201180628_event-enum.up.sql
@@ -1,0 +1,42 @@
+-- migrate Drop don't drop custom types
+DO $$ BEGIN
+    CREATE TYPE event_name AS ENUM (
+        'AccountTransferred',
+        'BlockCommissioned',
+        'BlockCreated',
+        'BlockProposerRewarded',
+        'BlockRewarded',
+        'GenesisCreated',
+        'Minted',
+        'MsgCreateValidatorCreated',
+        'MsgCreateValidatorFailed',
+        'MsgDelegateCreated',
+        'MsgDelegateFailed',
+        'MsgDepositCreated',
+        'MsgEditValidatorCreated',
+        'MsgEditValidatorFailed',
+        'MsgSendCreated',
+        'MsgSubmitParamUpdateProposalCreated',
+        'MsgUndelegateCreated',
+        'MsgUnjailCreated',
+        'MsgUnjailFailed',
+        'MsgVoteCreated',
+        'MsgWithdrawDelegatorRewardCreated',
+        'MsgWithdrawDelegatorRewardFailed',
+        'MsgWithdrawValidatorCommissionCreated',
+        'PowerChanged',
+        'RawBlockCreated',
+        'TransactionCreated',
+        'TransactionFailed',
+        'ValidatorJailed',
+        'ValidatorSlashed',
+
+        'FakeEvent',
+        'MockEvent'
+    );
+EXCEPTION
+    WHEN duplicate_object THEN null;
+END $$;
+
+alter table events
+    alter column name type event_name using name::event_name;


### PR DESCRIPTION
Solution:
- use enum for events.name

with this change, new event names need to add to the database with `alter type`.