### PR TITLE
Problem (wip #168): old event data are not deleted to reclaim disk space

### DIFF
--- a/appinterface/event/rdbstore_test.go
+++ b/appinterface/event/rdbstore_test.go
@@ -27,6 +27,7 @@ var _ = Describe("RdbEventStore", func() {
 			It("should insert an event properly without any error", func() {
 				registry := event.NewRegistry()
 				store := appinterface_event.NewRDbStore(pgxConn.ToHandle(), registry)
+				_ = store.EnsurePartitionTableExists(0)
 
 				event := test.NewFakeEvent()
 				err := store.Insert(event)
@@ -38,6 +39,7 @@ var _ = Describe("RdbEventStore", func() {
 			It("should insert multiple events properly without any error", func() {
 				registry := event.NewRegistry()
 				store := appinterface_event.NewRDbStore(pgxConn.ToHandle(), registry)
+				_ = store.EnsurePartitionTableExists(0)
 
 				events := []event.Event{test.NewFakeEvent(), test.NewFakeEvent()}
 				err := store.InsertAll(events)
@@ -49,6 +51,7 @@ var _ = Describe("RdbEventStore", func() {
 			It("should return nil when events table does not have any record", func() {
 				registry := event.NewRegistry()
 				store := appinterface_event.NewRDbStore(pgxConn.ToHandle(), registry)
+				_ = store.EnsurePartitionTableExists(0)
 
 				actual, err := store.GetLatestHeight()
 				Expect(err).To(BeNil())
@@ -58,6 +61,7 @@ var _ = Describe("RdbEventStore", func() {
 			It("should get 1 after insert fake event with height 1", func() {
 				registry := event.NewRegistry()
 				store := appinterface_event.NewRDbStore(pgxConn.ToHandle(), registry)
+				_ = store.EnsurePartitionTableExists(0)
 
 				// Insert an event with latestHeight 1
 				mockEvent := test.NewMockEvent()

--- a/cmd/chain-indexing/syncmanager.go
+++ b/cmd/chain-indexing/syncmanager.go
@@ -119,6 +119,9 @@ func (manager *SyncManager) SyncBlocks(latestHeight int64) error {
 			if err := executor.ExecAllCommands(); err != nil {
 				return fmt.Errorf("error generating all events%v", err)
 			}
+			if err := eventStore.EnsurePartitionTableExists(blockHeight); err != nil {
+				return fmt.Errorf("error creating events partition table%v", err)
+			}
 			if err := executor.StoreAllEvents(eventStore); err != nil {
 				return fmt.Errorf("error storing all events%v", err)
 			}

--- a/entity/event/store.go
+++ b/entity/event/store.go
@@ -10,4 +10,6 @@ type Store interface {
 
 	// InsertAll insert all events into store. It will rollback when the insert fails at any point.
 	InsertAll(evt []Event) error
+
+	EnsurePartitionTableExists(height int64) error
 }

--- a/entity/event/test/fakestore.go
+++ b/entity/event/test/fakestore.go
@@ -25,3 +25,7 @@ func (manager *FakeEventStore) Insert(evt entity_event.Event) error {
 func (manager *FakeEventStore) InsertAll(evts []entity_event.Event) error {
 	return nil
 }
+
+func (manager *FakeEventStore) EnsurePartitionTableExists(height int64) error {
+	return nil
+}

--- a/entity/event/test/mockstore.go
+++ b/entity/event/test/mockstore.go
@@ -36,3 +36,8 @@ func (manager *MockEventStore) InsertAll(evts []entity_event.Event) error {
 
 	return mockArgs.Error(0)
 }
+
+func (manager *MockEventStore) EnsurePartitionTableExists(height int64) error {
+	mockArgs := manager.Called(height)
+	return mockArgs.Error(0)
+}

--- a/migrations/20201101224555_events.up.sql
+++ b/migrations/20201101224555_events.up.sql
@@ -1,11 +1,10 @@
 CREATE TABLE events (
     id BIGSERIAL,
-    uuid VARCHAR,
+    uuid VARCHAR NOT NULL,
     height INT NOT NULL,
     name VARCHAR NOT NULL,
     version INT NOT NULL,
     payload JSONB NOT NULL,
-    PRIMARY KEY(id),
-    UNIQUE(uuid)
-);
+    UNIQUE(uuid, height)
+) partition by range (height);
 


### PR DESCRIPTION
Solution:
- first step: partition events table

after this, it's trivial to drop old tables, also good for long term performance of events table.