### PR TITLE
Problem: Transaction API return the first transaction with same hash

### DIFF
--- a/projection/transaction/view/transactions.go
+++ b/projection/transaction/view/transactions.go
@@ -191,7 +191,7 @@ func (transactionsView *BlockTransactions) FindByHash(txHash string) (*Transacti
 		"view_transactions",
 	).Where(
 		"hash = ?", txHash,
-	)
+	).OrderBy("id DESC")
 
 	sql, sqlArgs, err := selectStmtBuilder.ToSql()
 	if err != nil {


### PR DESCRIPTION
Solution: (Fix #303) API returns the last transaction in DB