### PR TITLE
Problem: Cannot parse Subscription module in genesis file

### DIFF
--- a/cmd/chain-indexing/config.go
+++ b/cmd/chain-indexing/config.go
@@ -102,7 +102,8 @@ type DebugConfig struct {
 }
 
 type TendermintConfig struct {
-	HTTPRPCURL string `toml:"http_rpc_url"`
+	HTTPRPCURL           string `toml:"http_rpc_url"`
+	StrictGenesisParsing bool   `toml:"strict_genesis_parsing"`
 }
 
 type CosmosAppConfig struct {

--- a/cmd/chain-indexing/indexservice.go
+++ b/cmd/chain-indexing/indexservice.go
@@ -19,6 +19,7 @@ type IndexService struct {
 	projections []projection_entity.Projection
 
 	systemMode            string
+	strictGenesisParsing  bool
 	accountAddressPrefix  string
 	consNodeAddressPrefix string
 	bondingDenom          string
@@ -39,6 +40,7 @@ func NewIndexService(
 		projections: projections,
 
 		systemMode:            config.System.Mode,
+		strictGenesisParsing:  config.Tendermint.StrictGenesisParsing,
 		consNodeAddressPrefix: config.Blockchain.ConNodeAddressPrefix,
 		accountAddressPrefix:  config.Blockchain.AccountAddressPrefix,
 		bondingDenom:          config.Blockchain.BondingDenom,
@@ -94,6 +96,7 @@ func (service *IndexService) RunEventStoreMode() error {
 			Config: SyncManagerConfig{
 				WindowSize:           service.windowSize,
 				TendermintRPCUrl:     service.tendermintHTTPRPCURL,
+				StrictGenesisParsing: service.strictGenesisParsing,
 				AccountAddressPrefix: service.accountAddressPrefix,
 				BondingDenom:         service.bondingDenom,
 			},

--- a/cmd/chain-indexing/syncmanager.go
+++ b/cmd/chain-indexing/syncmanager.go
@@ -18,10 +18,11 @@ import (
 const DEFAULT_POLLING_INTERVAL = 5 * time.Second
 
 type SyncManager struct {
-	rdbConn         rdb.Conn
-	client          *tendermint.HTTPClient
-	logger          applogger.Logger
-	pollingInterval time.Duration
+	rdbConn              rdb.Conn
+	client               *tendermint.HTTPClient
+	logger               applogger.Logger
+	pollingInterval      time.Duration
+	strictGenesisParsing bool
 
 	accountAddressPrefix string
 	bondingDenom         string
@@ -45,8 +46,9 @@ type SyncManagerParams struct {
 }
 
 type SyncManagerConfig struct {
-	WindowSize       int
-	TendermintRPCUrl string
+	WindowSize           int
+	TendermintRPCUrl     string
+	StrictGenesisParsing bool
 
 	AccountAddressPrefix string
 	BondingDenom         string
@@ -65,7 +67,8 @@ func NewSyncManager(
 		logger: params.Logger.WithFields(applogger.LogFields{
 			"module": "SyncManager",
 		}),
-		pollingInterval: DEFAULT_POLLING_INTERVAL,
+		pollingInterval:      DEFAULT_POLLING_INTERVAL,
+		strictGenesisParsing: params.Config.StrictGenesisParsing,
 
 		shouldSyncCh: make(chan bool, 1),
 

--- a/config/config.localnet.toml
+++ b/config/config.localnet.toml
@@ -20,6 +20,9 @@ window_size = 50
 
 [tendermint]
 http_rpc_url = "http://127.0.0.1:26657"
+# When enabled, genssi parsing will reject any non-Cosmos SDK built-in module
+# inside genesis file.
+strict_genesis_parsing = false
 
 [cosmosapp]
 http_rpc_url = "http://127.0.0.1:1317"

--- a/config/config.mainnet.toml
+++ b/config/config.mainnet.toml
@@ -20,6 +20,9 @@ window_size = 50
 
 [tendermint]
 http_rpc_url = "https://mainnet.crypto.org:26657"
+# When enabled, genssi parsing will reject any non-Cosmos SDK built-in module
+# inside genesis file.
+strict_genesis_parsing = false
 
 [cosmosapp]
 http_rpc_url = "https://mainnet.crypto.org:1317"

--- a/config/config.sample.toml
+++ b/config/config.sample.toml
@@ -20,6 +20,9 @@ window_size = 50
 
 [tendermint]
 http_rpc_url = "http://127.0.0.1:26657"
+# When enabled, genssi parsing will reject any non-Cosmos SDK built-in module
+# inside genesis file.
+strict_genesis_parsing = false
 
 [cosmosapp]
 http_rpc_url = "http://127.0.0.1:1317"

--- a/config/config.testnet.toml
+++ b/config/config.testnet.toml
@@ -20,6 +20,9 @@ window_size = 50
 
 [tendermint]
 http_rpc_url = "https://testnet-croeseid.crypto.org:26657"
+# When enabled, genssi parsing will reject any non-Cosmos SDK built-in module
+# inside genesis file.
+strict_genesis_parsing = false
 
 [cosmosapp]
 http_rpc_url = "https://testnet-croeseid.crypto.org:1317"

--- a/infrastructure/tendermint/httpclient.go
+++ b/infrastructure/tendermint/httpclient.go
@@ -17,12 +17,13 @@ import (
 )
 
 type HTTPClient struct {
-	httpClient       *http.Client
-	tendermintRPCUrl string
+	httpClient           *http.Client
+	tendermintRPCUrl     string
+	strictGenesisParsing bool
 }
 
 // NewHTTPClient returns a new HTTPClient for tendermint request
-func NewHTTPClient(tendermintRPCUrl string) *HTTPClient {
+func NewHTTPClient(tendermintRPCUrl string, strictGenesisParsing bool) *HTTPClient {
 	httpClient := &http.Client{
 		Timeout: 30 * time.Second,
 	}
@@ -30,6 +31,7 @@ func NewHTTPClient(tendermintRPCUrl string) *HTTPClient {
 	return &HTTPClient{
 		httpClient,
 		strings.TrimSuffix(tendermintRPCUrl, "/"),
+		strictGenesisParsing,
 	}
 }
 
@@ -42,7 +44,7 @@ func (client *HTTPClient) Genesis() (*genesis.Genesis, error) {
 	}
 	defer rawRespBody.Close()
 
-	genesis, err := ParseGenesisResp(rawRespBody)
+	genesis, err := ParseGenesisResp(rawRespBody, client.strictGenesisParsing)
 	if err != nil {
 		return nil, err
 	}

--- a/infrastructure/tendermint/parser.go
+++ b/infrastructure/tendermint/parser.go
@@ -17,10 +17,12 @@ import (
 )
 
 // Block related parsing functions
-func ParseGenesisResp(rawRespReader io.Reader) (*genesis.Genesis, error) {
+func ParseGenesisResp(rawRespReader io.Reader, strictParsing bool) (*genesis.Genesis, error) {
 	var genesisResp GenesisResp
 	jsonDecoder := jsoniter.NewDecoder(rawRespReader)
-	jsonDecoder.DisallowUnknownFields()
+	if strictParsing {
+		jsonDecoder.DisallowUnknownFields()
+	}
 	if err := jsonDecoder.Decode(&genesisResp); err != nil {
 		return nil, fmt.Errorf("error decoding Tendermint genesis response: %v", err)
 	}

--- a/usecase/parser/genesis_test.go
+++ b/usecase/parser/genesis_test.go
@@ -1,6 +1,9 @@
 package parser_test
 
 import (
+	"strings"
+
+	"github.com/crypto-com/chain-indexing/infrastructure/tendermint"
 	"github.com/crypto-com/chain-indexing/usecase/coin"
 	"github.com/crypto-com/chain-indexing/usecase/event"
 	"github.com/crypto-com/chain-indexing/usecase/model"
@@ -13,8 +16,17 @@ import (
 )
 
 var _ = Describe("Parse Genesis", func() {
+	It("should throw when parsing unknown fields with strict mode on", func() {
+		genesisReader := strings.NewReader(usecase_parser_test.GENESIS_RESP)
+		strict := true
+		_, err := tendermint.ParseGenesisResp(genesisReader, strict)
+		Expect(err).Should(HaveOccurred())
+		Expect(err).To(ContainSubstring("error decoding Tendermint genesis response"))
+	})
+
 	It("should return genesis command corresponding to genesis response", func() {
-		genesis := mustParseGenesisResp(usecase_parser_test.GENESIS_RESP)
+		strict := false
+		genesis := mustParseGenesisResp(usecase_parser_test.GENESIS_RESP, strict)
 
 		cmds, err := parser.ParseGenesisCommands(genesis)
 		Expect(err).To(BeNil())

--- a/usecase/parser/msg_test.go
+++ b/usecase/parser/msg_test.go
@@ -29,8 +29,8 @@ func mustParseBlockResultsResp(rawResp string) *model.BlockResults {
 	return blockResults
 }
 
-func mustParseGenesisResp(rawResp string) *genesis.Genesis {
-	genesis, err := tendermint.ParseGenesisResp(strings.NewReader(rawResp))
+func mustParseGenesisResp(rawResp string, strictParsing bool) *genesis.Genesis {
+	genesis, err := tendermint.ParseGenesisResp(strings.NewReader(rawResp), strictParsing)
 
 	if err != nil {
 		panic(fmt.Sprintf("error parsing block genesis response: %v", err))

--- a/usecase/parser/test/genesis.go
+++ b/usecase/parser/test/genesis.go
@@ -8955,6 +8955,17 @@ const GENESIS_RESP = `{
               ]
             }
           ],
+          "subscription": {
+            "params": {
+              "failure_tolerance": 3,
+              "gas_per_collection": 31288,
+              "subscription_enabled": true
+            },
+            "plans": [],
+            "starting_plan_id": "1",
+            "starting_subscription_id": "1",
+            "subscriptions": []
+          },
           "supply": [],
           "denom_metadata": [
             {


### PR DESCRIPTION
Solution: (Fix #401) Introduce strict genesis parsing config to bypass non-standard module