### PR TITLE
Problem: Missing signers in transaction API

### DIFF
--- a/migrations/20210805154736_alter_view_transactions_add_signer.down.sql
+++ b/migrations/20210805154736_alter_view_transactions_add_signer.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE view_transactions
+DROP signers;

--- a/migrations/20210805154736_alter_view_transactions_add_signer.up.sql
+++ b/migrations/20210805154736_alter_view_transactions_add_signer.up.sql
@@ -1,2 +1,2 @@
 ALTER TABLE view_transactions
-    ADD signers JSONB NOT NULL;
+    ADD signers JSONB NOT NULL DEFAULT '[]';

--- a/migrations/20210805154736_alter_view_transactions_add_signer.up.sql
+++ b/migrations/20210805154736_alter_view_transactions_add_signer.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE view_transactions
+    ADD signers JSONB NOT NULL;

--- a/projection/transaction/transaction.go
+++ b/projection/transaction/transaction.go
@@ -72,26 +72,26 @@ func (projection *Transaction) HandleEvents(height int64, events []event_entity.
 			blockTime = blockCreatedEvent.Block.Time
 			blockHash = blockCreatedEvent.Block.Hash
 		} else if transactionCreatedEvent, ok := event.(*event_usecase.TransactionCreated); ok {
-			tx := transaction_view.TransactionRow{
-				BlockHeight:   height,
-				BlockTime:     utctime.UTCTime{}, // placeholder
-				Hash:          transactionCreatedEvent.TxHash,
-				Index:         transactionCreatedEvent.Index,
-				Success:       true,
-				Code:          transactionCreatedEvent.Code,
-				Log:           transactionCreatedEvent.Log,
-				Fee:           transactionCreatedEvent.Fee,
-				FeePayer:      transactionCreatedEvent.FeePayer,
-				FeeGranter:    transactionCreatedEvent.FeeGranter,
-				GasWanted:     transactionCreatedEvent.GasWanted,
-				GasUsed:       transactionCreatedEvent.GasUsed,
-				Memo:          transactionCreatedEvent.Memo,
-				TimeoutHeight: transactionCreatedEvent.TimeoutHeight,
-				Messages:      make([]transaction_view.TransactionRowMessage, 0),
-			}
+			if transactionCreatedEvent != nil {
+				tx := transaction_view.TransactionRow{
+					BlockHeight:   height,
+					BlockTime:     utctime.UTCTime{}, // placeholder
+					Hash:          transactionCreatedEvent.TxHash,
+					Index:         transactionCreatedEvent.Index,
+					Success:       true,
+					Code:          transactionCreatedEvent.Code,
+					Log:           transactionCreatedEvent.Log,
+					Fee:           transactionCreatedEvent.Fee,
+					FeePayer:      transactionCreatedEvent.FeePayer,
+					FeeGranter:    transactionCreatedEvent.FeeGranter,
+					GasWanted:     transactionCreatedEvent.GasWanted,
+					GasUsed:       transactionCreatedEvent.GasUsed,
+					Memo:          transactionCreatedEvent.Memo,
+					TimeoutHeight: transactionCreatedEvent.TimeoutHeight,
+					Messages:      make([]transaction_view.TransactionRowMessage, 0),
+				}
 
-			signers := make([]transaction_view.TransactionRowSigner, 0)
-			if transactionCreatedEvent != nil && transactionCreatedEvent.Signers != nil {
+				signers := make([]transaction_view.TransactionRowSigner, 0)
 				for _, transactionCreatedEventSigner := range transactionCreatedEvent.Signers {
 					signers = append(signers, transaction_view.TransactionRowSigner{
 						Type:            transactionCreatedEventSigner.Type,
@@ -102,9 +102,9 @@ func (projection *Transaction) HandleEvents(height int64, events []event_entity.
 						Address:         transactionCreatedEventSigner.Address,
 					})
 				}
+				tx.Signers = signers
+				txs = append(txs, tx)
 			}
-			tx.Signers = signers
-			txs = append(txs, tx)
 		} else if transactionFailedEvent, ok := event.(*event_usecase.TransactionFailed); ok {
 			tx := transaction_view.TransactionRow{
 				BlockHeight:   height,
@@ -125,17 +125,15 @@ func (projection *Transaction) HandleEvents(height int64, events []event_entity.
 			}
 
 			signers := make([]transaction_view.TransactionRowSigner, 0)
-			if transactionCreatedEvent != nil && transactionCreatedEvent.Signers != nil {
-				for _, transactionCreatedEventSigner := range transactionCreatedEvent.Signers {
-					signers = append(signers, transaction_view.TransactionRowSigner{
-						Type:            transactionCreatedEventSigner.Type,
-						IsMultiSig:      transactionCreatedEventSigner.IsMultiSig,
-						Pubkeys:         transactionCreatedEventSigner.Pubkeys,
-						MaybeThreshold:  transactionCreatedEventSigner.MaybeThreshold,
-						AccountSequence: transactionCreatedEventSigner.AccountSequence,
-						Address:         transactionCreatedEventSigner.Address,
-					})
-				}
+			for _, transactionFailedEventSigner := range transactionFailedEvent.Signers {
+				signers = append(signers, transaction_view.TransactionRowSigner{
+					Type:            transactionFailedEventSigner.Type,
+					IsMultiSig:      transactionFailedEventSigner.IsMultiSig,
+					Pubkeys:         transactionFailedEventSigner.Pubkeys,
+					MaybeThreshold:  transactionFailedEventSigner.MaybeThreshold,
+					AccountSequence: transactionFailedEventSigner.AccountSequence,
+					Address:         transactionFailedEventSigner.Address,
+				})
 			}
 
 			tx.Signers = signers

--- a/projection/transaction/transaction.go
+++ b/projection/transaction/transaction.go
@@ -72,7 +72,7 @@ func (projection *Transaction) HandleEvents(height int64, events []event_entity.
 			blockTime = blockCreatedEvent.Block.Time
 			blockHash = blockCreatedEvent.Block.Hash
 		} else if transactionCreatedEvent, ok := event.(*event_usecase.TransactionCreated); ok {
-			txs = append(txs, transaction_view.TransactionRow{
+			tx := transaction_view.TransactionRow{
 				BlockHeight:   height,
 				BlockTime:     utctime.UTCTime{}, // placeholder
 				Hash:          transactionCreatedEvent.TxHash,
@@ -88,9 +88,25 @@ func (projection *Transaction) HandleEvents(height int64, events []event_entity.
 				Memo:          transactionCreatedEvent.Memo,
 				TimeoutHeight: transactionCreatedEvent.TimeoutHeight,
 				Messages:      make([]transaction_view.TransactionRowMessage, 0),
-			})
+			}
+
+			signers := make([]transaction_view.TransactionRowSigner, 0)
+			if transactionCreatedEvent != nil && transactionCreatedEvent.Signers != nil {
+				for _, transactionCreatedEventSigner := range transactionCreatedEvent.Signers {
+					signers = append(signers, transaction_view.TransactionRowSigner{
+						Type:            transactionCreatedEventSigner.Type,
+						IsMultiSig:      transactionCreatedEventSigner.IsMultiSig,
+						Pubkeys:         transactionCreatedEventSigner.Pubkeys,
+						MaybeThreshold:  transactionCreatedEventSigner.MaybeThreshold,
+						AccountSequence: transactionCreatedEventSigner.AccountSequence,
+						Address:         transactionCreatedEventSigner.Address,
+					})
+				}
+			}
+			tx.Signers = signers
+			txs = append(txs, tx)
 		} else if transactionFailedEvent, ok := event.(*event_usecase.TransactionFailed); ok {
-			txs = append(txs, transaction_view.TransactionRow{
+			tx := transaction_view.TransactionRow{
 				BlockHeight:   height,
 				BlockTime:     utctime.UTCTime{}, // placeholder
 				Hash:          transactionFailedEvent.TxHash,
@@ -106,7 +122,24 @@ func (projection *Transaction) HandleEvents(height int64, events []event_entity.
 				Memo:          transactionFailedEvent.Memo,
 				TimeoutHeight: transactionFailedEvent.TimeoutHeight,
 				Messages:      make([]transaction_view.TransactionRowMessage, 0),
-			})
+			}
+
+			signers := make([]transaction_view.TransactionRowSigner, 0)
+			if transactionCreatedEvent != nil && transactionCreatedEvent.Signers != nil {
+				for _, transactionCreatedEventSigner := range transactionCreatedEvent.Signers {
+					signers = append(signers, transaction_view.TransactionRowSigner{
+						Type:            transactionCreatedEventSigner.Type,
+						IsMultiSig:      transactionCreatedEventSigner.IsMultiSig,
+						Pubkeys:         transactionCreatedEventSigner.Pubkeys,
+						MaybeThreshold:  transactionCreatedEventSigner.MaybeThreshold,
+						AccountSequence: transactionCreatedEventSigner.AccountSequence,
+						Address:         transactionCreatedEventSigner.Address,
+					})
+				}
+			}
+
+			tx.Signers = signers
+			txs = append(txs, tx)
 		} else if msgEvent, ok := event.(event_usecase.MsgEvent); ok {
 			if _, exist := txMsgs[msgEvent.TxHash()]; !exist {
 				txMsgs[msgEvent.TxHash()] = make([]event_usecase.MsgEvent, 0)

--- a/projection/transaction/transaction.go
+++ b/projection/transaction/transaction.go
@@ -72,39 +72,37 @@ func (projection *Transaction) HandleEvents(height int64, events []event_entity.
 			blockTime = blockCreatedEvent.Block.Time
 			blockHash = blockCreatedEvent.Block.Hash
 		} else if transactionCreatedEvent, ok := event.(*event_usecase.TransactionCreated); ok {
-			if transactionCreatedEvent != nil {
-				tx := transaction_view.TransactionRow{
-					BlockHeight:   height,
-					BlockTime:     utctime.UTCTime{}, // placeholder
-					Hash:          transactionCreatedEvent.TxHash,
-					Index:         transactionCreatedEvent.Index,
-					Success:       true,
-					Code:          transactionCreatedEvent.Code,
-					Log:           transactionCreatedEvent.Log,
-					Fee:           transactionCreatedEvent.Fee,
-					FeePayer:      transactionCreatedEvent.FeePayer,
-					FeeGranter:    transactionCreatedEvent.FeeGranter,
-					GasWanted:     transactionCreatedEvent.GasWanted,
-					GasUsed:       transactionCreatedEvent.GasUsed,
-					Memo:          transactionCreatedEvent.Memo,
-					TimeoutHeight: transactionCreatedEvent.TimeoutHeight,
-					Messages:      make([]transaction_view.TransactionRowMessage, 0),
-				}
-
-				signers := make([]transaction_view.TransactionRowSigner, 0)
-				for _, transactionCreatedEventSigner := range transactionCreatedEvent.Signers {
-					signers = append(signers, transaction_view.TransactionRowSigner{
-						Type:            transactionCreatedEventSigner.Type,
-						IsMultiSig:      transactionCreatedEventSigner.IsMultiSig,
-						Pubkeys:         transactionCreatedEventSigner.Pubkeys,
-						MaybeThreshold:  transactionCreatedEventSigner.MaybeThreshold,
-						AccountSequence: transactionCreatedEventSigner.AccountSequence,
-						Address:         transactionCreatedEventSigner.Address,
-					})
-				}
-				tx.Signers = signers
-				txs = append(txs, tx)
+			tx := transaction_view.TransactionRow{
+				BlockHeight:   height,
+				BlockTime:     utctime.UTCTime{}, // placeholder
+				Hash:          transactionCreatedEvent.TxHash,
+				Index:         transactionCreatedEvent.Index,
+				Success:       true,
+				Code:          transactionCreatedEvent.Code,
+				Log:           transactionCreatedEvent.Log,
+				Fee:           transactionCreatedEvent.Fee,
+				FeePayer:      transactionCreatedEvent.FeePayer,
+				FeeGranter:    transactionCreatedEvent.FeeGranter,
+				GasWanted:     transactionCreatedEvent.GasWanted,
+				GasUsed:       transactionCreatedEvent.GasUsed,
+				Memo:          transactionCreatedEvent.Memo,
+				TimeoutHeight: transactionCreatedEvent.TimeoutHeight,
+				Messages:      make([]transaction_view.TransactionRowMessage, 0),
 			}
+
+			signers := make([]transaction_view.TransactionRowSigner, 0)
+			for _, transactionCreatedEventSigner := range transactionCreatedEvent.Signers {
+				signers = append(signers, transaction_view.TransactionRowSigner{
+					Type:            transactionCreatedEventSigner.Type,
+					IsMultiSig:      transactionCreatedEventSigner.IsMultiSig,
+					Pubkeys:         transactionCreatedEventSigner.Pubkeys,
+					MaybeThreshold:  transactionCreatedEventSigner.MaybeThreshold,
+					AccountSequence: transactionCreatedEventSigner.AccountSequence,
+					Address:         transactionCreatedEventSigner.Address,
+				})
+			}
+			tx.Signers = signers
+			txs = append(txs, tx)
 		} else if transactionFailedEvent, ok := event.(*event_usecase.TransactionFailed); ok {
 			tx := transaction_view.TransactionRow{
 				BlockHeight:   height,

--- a/projection/transaction/view/transactions.go
+++ b/projection/transaction/view/transactions.go
@@ -76,7 +76,7 @@ func (transactionsView *BlockTransactions) InsertAll(transactions []TransactionR
 		var signersJSON string
 		if signersJSON, marshalErr = jsoniter.MarshalToString(transaction.Signers); marshalErr != nil {
 			return fmt.Errorf(
-				"error JSON marshalling block transation fee for insertion: %v: %w", marshalErr, rdb.ErrBuildSQLStmt,
+				"error JSON marshalling block transation signers for insertion: %v: %w", marshalErr, rdb.ErrBuildSQLStmt,
 			)
 		}
 
@@ -163,7 +163,7 @@ func (transactionsView *BlockTransactions) Insert(transaction *TransactionRow) e
 
 	var signersJSON string
 	if signersJSON, err = jsoniter.MarshalToString(transaction.Signers); err != nil {
-		return fmt.Errorf("error JSON marshalling block transation fee for insertion: %v: %w", err, rdb.ErrBuildSQLStmt)
+		return fmt.Errorf("error JSON marshalling block transation signers for insertion: %v: %w", err, rdb.ErrBuildSQLStmt)
 	}
 
 	result, err := transactionsView.rdb.Exec(sql,
@@ -275,7 +275,7 @@ func (transactionsView *BlockTransactions) FindByHash(txHash string) (*Transacti
 
 	var signers []TransactionRowSigner
 	if unmarshalErr := jsoniter.UnmarshalFromString(*signersJSON, &signers); unmarshalErr != nil {
-		return nil, fmt.Errorf("error unmarshalling transaction messages JSON: %v: %w", unmarshalErr, rdb.ErrQuery)
+		return nil, fmt.Errorf("error unmarshalling transaction signers JSON: %v: %w", unmarshalErr, rdb.ErrQuery)
 	}
 	transaction.Signers = signers
 
@@ -397,7 +397,7 @@ func (transactionsView *BlockTransactions) List(
 
 		var signers []TransactionRowSigner
 		if unmarshalErr := jsoniter.UnmarshalFromString(*signersJSON, &signers); unmarshalErr != nil {
-			return nil, nil, fmt.Errorf("error unmarshalling transaction messages JSON: %v: %w", unmarshalErr, rdb.ErrQuery)
+			return nil, nil, fmt.Errorf("error unmarshalling transaction signers JSON: %v: %w", unmarshalErr, rdb.ErrQuery)
 		}
 		transaction.Signers = signers
 
@@ -499,7 +499,7 @@ func (transactionsView *BlockTransactions) Search(keyword string) ([]Transaction
 
 		var signers []TransactionRowSigner
 		if unmarshalErr := jsoniter.UnmarshalFromString(*signersJSON, &signers); unmarshalErr != nil {
-			return nil, fmt.Errorf("error unmarshalling transaction messages JSON: %v: %w", unmarshalErr, rdb.ErrQuery)
+			return nil, fmt.Errorf("error unmarshalling transaction signers JSON: %v: %w", unmarshalErr, rdb.ErrQuery)
 		}
 		transaction.Signers = signers
 


### PR DESCRIPTION
Solution: fixed #438 by adding signers field into transaction struct

Modified response would be like:
```
        {
            "blockHeight": 13618,
            "blockHash": "625B78B0C643021B9C917BFCC2E8CDE8F9A39341DFCB538EFB5A86ED26B5B87F",
            ...,
            "signers": [
                {
                    "type": "/cosmos.crypto.secp256k1.PubKey",
                    "isMultiSig": false,
                    "pubkeys": [
                        "Ah5t0VGq6AIcsvPYT1lYjKq6thZE3kpaPtbolj61vgcU"
                    ],
                    "accountSequence": 3,
                    "address": "tcro1f5rds2xlqswhpxynp6v62k4kz328fxd00059w4"
                }
            ]
        }
```