### PR TITLE
Problem: Missing estimated APY based on recent n blocks

### DIFF
--- a/infrastructure/httpapi/handlers/validators.go
+++ b/infrastructure/httpapi/handlers/validators.go
@@ -274,7 +274,7 @@ func (handler *Validators) getGlobalAPY() (*big.Float, error) {
 }
 
 func (handler *Validators) getAverageBlockTime() (*big.Float, error) {
-	// Average block time calculattion
+	// Average block time calculation
 	//
 	// Case A: totalBlockCount <= nRecentBlocks, calculate with blocks from Genesis block to Latest block
 	// Case B: totalBlockCount > nRecentBlocks, calculate with n recent blocks
@@ -305,11 +305,12 @@ func (handler *Validators) getAverageBlockTime() (*big.Float, error) {
 
 	nRecentBlocks := big.NewInt(nRecentBlocksInInt)
 
-	isTotalBlockCountExcess := (totalBlockCount.Cmp(nRecentBlocks) == 1)
+	hasNBlocksSinceGenesis := (totalBlockCount.Cmp(nRecentBlocks) == 1)
 
 	var averageBlockTimeMilliSecond *big.Float
 	// Determine case A or case B
-	if isTotalBlockCountExcess {
+	if hasNBlocksSinceGenesis {
+		// Case B
 		latestBlockHeight, err := handler.blockView.Count()
 		if err != nil {
 			return nil, fmt.Errorf("error fetching latest block height: %v", err)
@@ -331,7 +332,6 @@ func (handler *Validators) getAverageBlockTime() (*big.Float, error) {
 		// Calculate total time in generating n recent blocks
 		nRecentBlocksTotalTime := latestBlock.Time.UnixNano() - startBlock.Time.UnixNano()
 
-		// Case B
 		nRecentBlocksTotalTimeMilliSecond := new(big.Float).Quo(
 			new(big.Float).SetInt64(nRecentBlocksTotalTime),
 			new(big.Float).SetInt64(int64(1000000)),

--- a/infrastructure/httpapi/handlers/validators.go
+++ b/infrastructure/httpapi/handlers/validators.go
@@ -309,6 +309,7 @@ func (handler *Validators) getAverageBlockTime() (*big.Float, error) {
 	isTotalBlockCountExcess := (totalBlockCount.Cmp(nRecentBlocks) == 1)
 
 	// Case B: totalBlockCount > nRecentBlocks, calculate with n recent blocks
+	var averageBlockTimeMilliSecond *big.Float
 	if isTotalBlockCountExcess {
 		latestBlockHeight, err := handler.blockView.Count()
 		if err != nil {
@@ -331,18 +332,28 @@ func (handler *Validators) getAverageBlockTime() (*big.Float, error) {
 		// Calculate total time in generating n recent blocks
 		nRecentBlocksTotalTime := latestBlock.Time.UnixNano() - startBlock.Time.UnixNano()
 
-		totalBlockTime = new(big.Int).SetInt64(nRecentBlocksTotalTime)
-		totalBlockCount = nRecentBlocks
+		// Case B
+		nRecentBlocksTotalTimeMilliSecond := new(big.Float).Quo(
+			new(big.Float).SetInt64(nRecentBlocksTotalTime),
+			new(big.Float).SetInt64(int64(1000000)),
+		)
+		averageBlockTimeMilliSecond = new(big.Float).Quo(
+			nRecentBlocksTotalTimeMilliSecond,
+			new(big.Float).SetInt(nRecentBlocks),
+		)
+
+	} else {
+		// Case A
+		totalBlockTimeMilliSecond := new(big.Float).Quo(
+			new(big.Float).SetInt(totalBlockTime),
+			new(big.Float).SetInt64(int64(1000000)),
+		)
+		averageBlockTimeMilliSecond = new(big.Float).Quo(
+			totalBlockTimeMilliSecond,
+			new(big.Float).SetInt(totalBlockCount),
+		)
 	}
 
-	totalBlockTimeMilliSecond := new(big.Float).Quo(
-		new(big.Float).SetInt(totalBlockTime),
-		new(big.Float).SetInt64(int64(1000000)),
-	)
-	averageBlockTimeMilliSecond := new(big.Float).Quo(
-		totalBlockTimeMilliSecond,
-		new(big.Float).SetInt(totalBlockCount),
-	)
 	averageBlockTime := new(big.Float).Quo(
 		averageBlockTimeMilliSecond,
 		big.NewFloat(1000),

--- a/infrastructure/httpapi/handlers/validators.go
+++ b/infrastructure/httpapi/handlers/validators.go
@@ -281,7 +281,6 @@ func (handler *Validators) getAverageBlockTime() (*big.Float, error) {
 	var totalBlockTime = big.NewInt(0)
 	var totalBlockCount = big.NewInt(1)
 
-	// Case A: totalBlockCount <= nRecentBlocks, calculate with blocks from Genesis block to Latest block
 	if rawTotalBlockTime, err := handler.chainStatsView.FindBy(chainstats.TOTAL_BLOCK_TIME); err != nil {
 		return nil, fmt.Errorf("error fetching total block time: %v", err)
 	} else {
@@ -308,8 +307,8 @@ func (handler *Validators) getAverageBlockTime() (*big.Float, error) {
 
 	isTotalBlockCountExcess := (totalBlockCount.Cmp(nRecentBlocks) == 1)
 
-	// Case B: totalBlockCount > nRecentBlocks, calculate with n recent blocks
 	var averageBlockTimeMilliSecond *big.Float
+	// Determine case A or case B
 	if isTotalBlockCountExcess {
 		latestBlockHeight, err := handler.blockView.Count()
 		if err != nil {

--- a/projection/account_transaction/view/account_transactions_total.go
+++ b/projection/account_transaction/view/account_transactions_total.go
@@ -23,7 +23,7 @@ func (total *AccountTransactionsTotal) Search(address string) (bool, error) {
 		return false, err
 	}
 	if numberOfRowsFound == 0 {
-		return false, err
+		return false, nil
 	}
 	return true, nil
 }


### PR DESCRIPTION
Solution: Fixed #452. Calculate averageBlockTime using n latest blocks.
