### PR TITLE
Problem: missing IBC channel debug projection

### DIFF
--- a/config/config.localnet.toml
+++ b/config/config.localnet.toml
@@ -77,6 +77,7 @@ enables = [
     "Validator",
     "ValidatorStats",
     "NFT",
-    "IBCChannel",
 #    "CryptoComNFT",
+    "IBCChannel",
+#    "IBCChannelTxMsgTrace",
 ]

--- a/config/config.mainnet.toml
+++ b/config/config.mainnet.toml
@@ -77,6 +77,7 @@ enables = [
     "Validator",
     "ValidatorStats",
     "NFT",
-    "IBCChannel",
 #    "CryptoComNFT",
+    "IBCChannel",
+#    "IBCChannelTxMsgTrace",
 ]

--- a/config/config.sample.toml
+++ b/config/config.sample.toml
@@ -77,6 +77,7 @@ enables = [
     "Validator",
     "ValidatorStats",
     "NFT",
-    "IBCChannel",
 #    "CryptoComNFT",
+    "IBCChannel",
+#    "IBCChannelTxMsgTrace",
 ]

--- a/config/config.testnet-3.toml
+++ b/config/config.testnet-3.toml
@@ -77,6 +77,7 @@ enables = [
     "Validator",
     "ValidatorStats",
     "NFT",
-    "IBCChannel",
 #    "CryptoComNFT",
+    "IBCChannel",
+#    "IBCChannelTxMsgTrace",
 ]

--- a/config/config.testnet-4.toml
+++ b/config/config.testnet-4.toml
@@ -77,6 +77,7 @@ enables = [
     "Validator",
     "ValidatorStats",
     "NFT",
-    "IBCChannel",
 #    "CryptoComNFT",
+    "IBCChannel",
+#    "IBCChannelTxMsgTrace",
 ]

--- a/config/config.testnet.toml
+++ b/config/config.testnet.toml
@@ -77,6 +77,7 @@ enables = [
     "Validator",
     "ValidatorStats",
     "NFT",
-    "IBCChannel",
 #    "CryptoComNFT",
+    "IBCChannel",
+#    "IBCChannelTxMsgTrace",
 ]

--- a/migrations/20210830173217_view_ibc_channel_messages.down.sql
+++ b/migrations/20210830173217_view_ibc_channel_messages.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS view_ibc_channel_messages;

--- a/migrations/20210830173217_view_ibc_channel_messages.up.sql
+++ b/migrations/20210830173217_view_ibc_channel_messages.up.sql
@@ -1,0 +1,15 @@
+CREATE TABLE view_ibc_channel_messages (
+    id BIGSERIAL,
+    channel_id VARCHAR NOT NULL,
+    block_height BIGINT NOT NULL,
+    source_channel VARCHAR NOT NULL,
+    destination_channel VARCHAR NOT NULL,
+    denom VARCHAR NOT NULL,
+    amount VARCHAR NOT NULL,
+    success VARCHAR NOT NULL,
+    error VARCHAR NOT NULL,
+    message_type VARCHAR NOT NULL,
+    message JSONB NOT NULL,
+    updated_bonded_tokens JSONB NOT NULL,
+    PRIMARY KEY(id)
+);

--- a/projection/ibc_channel/ibc_channel.go
+++ b/projection/ibc_channel/ibc_channel.go
@@ -32,8 +32,12 @@ type Config struct {
 }
 
 func NewIBCChannel(logger applogger.Logger, rdbConn rdb.Conn, config Config) *IBCChannel {
+	projectionID := "IBCChannel"
+	if config.EnableTxMsgTrace {
+		projectionID = "IBCChannelTxMsgTrace"
+	}
 	return &IBCChannel{
-		rdbprojectionbase.NewRDbBase(rdbConn.ToHandle(), "IBCChannel"),
+		rdbprojectionbase.NewRDbBase(rdbConn.ToHandle(), projectionID),
 
 		rdbConn,
 		logger,

--- a/projection/ibc_channel/ibc_channel.go
+++ b/projection/ibc_channel/ibc_channel.go
@@ -2,6 +2,7 @@ package ibc_channel
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/crypto-com/chain-indexing/appinterface/projection/rdbprojectionbase"
 	"github.com/crypto-com/chain-indexing/appinterface/rdb"
@@ -12,6 +13,7 @@ import (
 	ibc_channel_view "github.com/crypto-com/chain-indexing/projection/ibc_channel/view"
 	"github.com/crypto-com/chain-indexing/usecase/coin"
 	event_usecase "github.com/crypto-com/chain-indexing/usecase/event"
+	jsoniter "github.com/json-iterator/go"
 )
 
 var _ entity_projection.Projection = &IBCChannel{}
@@ -21,14 +23,22 @@ type IBCChannel struct {
 
 	rdbConn rdb.Conn
 	logger  applogger.Logger
+
+	config Config
 }
 
-func NewIBCChannel(logger applogger.Logger, rdbConn rdb.Conn) *IBCChannel {
+type Config struct {
+	EnableTxMsgTrace bool
+}
+
+func NewIBCChannel(logger applogger.Logger, rdbConn rdb.Conn, config Config) *IBCChannel {
 	return &IBCChannel{
 		rdbprojectionbase.NewRDbBase(rdbConn.ToHandle(), "IBCChannel"),
 
 		rdbConn,
 		logger,
+
+		config,
 	}
 }
 
@@ -71,6 +81,7 @@ func (projection *IBCChannel) HandleEvents(height int64, events []event_entity.E
 	ibcChannelsView := ibc_channel_view.NewIBCChannels(rdbTxHandle)
 	ibcClientsView := ibc_channel_view.NewIBCClients(rdbTxHandle)
 	ibcConnectionsView := ibc_channel_view.NewIBCConnections(rdbTxHandle)
+	ibcChannelMessagesView := ibc_channel_view.NewIBCChannelMessages(rdbTxHandle)
 
 	// Get the block time of current height
 	var blockTime utctime.UTCTime
@@ -268,6 +279,32 @@ func (projection *IBCChannel) HandleEvents(height int64, events []event_entity.E
 				return fmt.Errorf("error updating channel last_activity_time: %w", err)
 			}
 
+			if projection.config.EnableTxMsgTrace {
+
+				amount := msgIBCTransferTransfer.Params.Token.Amount
+				msg, err := msgIBCTransferTransfer.ToJSON()
+				if err != nil {
+					return fmt.Errorf("error msgIBCTransferTransfer.ToJSON(): %w", err)
+				}
+
+				if err := ibcChannelMessagesView.Insert(&ibc_channel_view.IBCChannelMessageRow{
+					ChannelID:           channelID,
+					BlockHeight:         height,
+					SourceChannel:       msgIBCTransferTransfer.Params.SourceChannel,
+					DestinationChannel:  msgIBCTransferTransfer.Params.DestinationChannel,
+					Denom:               msgIBCTransferTransfer.Params.Token.Denom,
+					Amount:              strconv.FormatUint(amount, 10),
+					Success:             "",
+					Error:               "",
+					MessageType:         msgIBCTransferTransfer.MsgName,
+					Message:             msg,
+					UpdatedBondedTokens: "{}",
+				}); err != nil {
+					return fmt.Errorf("error adding tx trace when MsgIBCTransferTransfer: %w", err)
+				}
+
+			}
+
 		} else if msgIBCRecvPacket, ok := event.(*event_usecase.MsgIBCRecvPacket); ok {
 
 			// Transfer started by destination chain
@@ -305,6 +342,42 @@ func (projection *IBCChannel) HandleEvents(height int64, events []event_entity.E
 					destinationPortID,
 				); err != nil {
 					return fmt.Errorf("error updateChannelBondedTokensWhenMsgIBCRecvPacket: %w", err)
+				}
+
+			}
+
+			if projection.config.EnableTxMsgTrace {
+
+				msg, err := msgIBCRecvPacket.ToJSON()
+				if err != nil {
+					return fmt.Errorf("error msgIBCRecvPacket.ToJSON(): %w", err)
+				}
+				success := strconv.FormatBool(msgIBCRecvPacket.Params.MaybeFungibleTokenPacketData.Success)
+
+				// Here the bonded_tokens has already been updated by the above updateBondedTokensWhenXXXX()
+				updatedBondedTokens, err := ibcChannelsView.FindBondedTokensBy(channelID)
+				if err != nil {
+					return fmt.Errorf("error finding channel updated bonded_tokens: %w", err)
+				}
+				updatedBondedTokensJSON, err := jsoniter.MarshalToString(updatedBondedTokens)
+				if err != nil {
+					return fmt.Errorf("error marshal updatedBondedTokens to string: %w", err)
+				}
+
+				if err := ibcChannelMessagesView.Insert(&ibc_channel_view.IBCChannelMessageRow{
+					ChannelID:           channelID,
+					BlockHeight:         height,
+					SourceChannel:       msgIBCRecvPacket.Params.Packet.SourceChannel,
+					DestinationChannel:  msgIBCRecvPacket.Params.Packet.DestinationChannel,
+					Denom:               msgIBCRecvPacket.Params.MaybeFungibleTokenPacketData.Denom,
+					Amount:              msgIBCRecvPacket.Params.MaybeFungibleTokenPacketData.Amount.String(),
+					Success:             success,
+					Error:               msgIBCRecvPacket.Params.PacketAck.MaybeError,
+					MessageType:         msgIBCRecvPacket.MsgName,
+					Message:             msg,
+					UpdatedBondedTokens: updatedBondedTokensJSON,
+				}); err != nil {
+					return fmt.Errorf("error adding tx trace when MsgIBCRecvPacket: %w", err)
 				}
 
 			}
@@ -347,6 +420,42 @@ func (projection *IBCChannel) HandleEvents(height int64, events []event_entity.E
 					destinationPortID,
 				); err != nil {
 					return fmt.Errorf("error updateChannelBondedTokensWhenMsgIBCAcknowledgement: %w", err)
+				}
+
+			}
+
+			if projection.config.EnableTxMsgTrace {
+
+				msg, err := msgIBCAcknowledgement.ToJSON()
+				if err != nil {
+					return fmt.Errorf("error msgIBCAcknowledgement.ToJSON(): %w", err)
+				}
+				success := strconv.FormatBool(msgIBCAcknowledgement.Params.MaybeFungibleTokenPacketData.Success)
+
+				// Here the bonded_tokens has already been updated by the above updateBondedTokensWhenXXXX()
+				updatedBondedTokens, err := ibcChannelsView.FindBondedTokensBy(channelID)
+				if err != nil {
+					return fmt.Errorf("error finding channel updated bonded_tokens: %w", err)
+				}
+				updatedBondedTokensJSON, err := jsoniter.MarshalToString(updatedBondedTokens)
+				if err != nil {
+					return fmt.Errorf("error marshal updatedBondedTokens to string: %w", err)
+				}
+
+				if err := ibcChannelMessagesView.Insert(&ibc_channel_view.IBCChannelMessageRow{
+					ChannelID:           channelID,
+					BlockHeight:         height,
+					SourceChannel:       msgIBCAcknowledgement.Params.Packet.SourceChannel,
+					DestinationChannel:  msgIBCAcknowledgement.Params.Packet.DestinationChannel,
+					Denom:               msgIBCAcknowledgement.Params.MaybeFungibleTokenPacketData.Denom,
+					Amount:              msgIBCAcknowledgement.Params.MaybeFungibleTokenPacketData.Amount.String(),
+					Success:             success,
+					Error:               msgIBCAcknowledgement.Params.MaybeFungibleTokenPacketData.MaybeError,
+					MessageType:         msgIBCAcknowledgement.MsgName,
+					Message:             msg,
+					UpdatedBondedTokens: updatedBondedTokensJSON,
+				}); err != nil {
+					return fmt.Errorf("error adding tx trace when MsgIBCAcknowledgement: %w", err)
 				}
 
 			}

--- a/projection/ibc_channel/ibc_channel.go
+++ b/projection/ibc_channel/ibc_channel.go
@@ -354,6 +354,11 @@ func (projection *IBCChannel) HandleEvents(height int64, events []event_entity.E
 				}
 				success := strconv.FormatBool(msgIBCRecvPacket.Params.MaybeFungibleTokenPacketData.Success)
 
+				maybeError := ""
+				if msgIBCRecvPacket.Params.PacketAck.MaybeError != nil {
+					maybeError = *msgIBCRecvPacket.Params.PacketAck.MaybeError
+				}
+
 				// Here the bonded_tokens has already been updated by the above updateBondedTokensWhenXXXX()
 				updatedBondedTokens, err := ibcChannelsView.FindBondedTokensBy(channelID)
 				if err != nil {
@@ -372,7 +377,7 @@ func (projection *IBCChannel) HandleEvents(height int64, events []event_entity.E
 					Denom:               msgIBCRecvPacket.Params.MaybeFungibleTokenPacketData.Denom,
 					Amount:              msgIBCRecvPacket.Params.MaybeFungibleTokenPacketData.Amount.String(),
 					Success:             success,
-					Error:               msgIBCRecvPacket.Params.PacketAck.MaybeError,
+					Error:               maybeError,
 					MessageType:         msgIBCRecvPacket.MsgName,
 					Message:             msg,
 					UpdatedBondedTokens: updatedBondedTokensJSON,
@@ -432,6 +437,11 @@ func (projection *IBCChannel) HandleEvents(height int64, events []event_entity.E
 				}
 				success := strconv.FormatBool(msgIBCAcknowledgement.Params.MaybeFungibleTokenPacketData.Success)
 
+				maybeError := ""
+				if msgIBCAcknowledgement.Params.MaybeFungibleTokenPacketData.MaybeError != nil {
+					maybeError = *msgIBCAcknowledgement.Params.MaybeFungibleTokenPacketData.MaybeError
+				}
+
 				// Here the bonded_tokens has already been updated by the above updateBondedTokensWhenXXXX()
 				updatedBondedTokens, err := ibcChannelsView.FindBondedTokensBy(channelID)
 				if err != nil {
@@ -450,7 +460,7 @@ func (projection *IBCChannel) HandleEvents(height int64, events []event_entity.E
 					Denom:               msgIBCAcknowledgement.Params.MaybeFungibleTokenPacketData.Denom,
 					Amount:              msgIBCAcknowledgement.Params.MaybeFungibleTokenPacketData.Amount.String(),
 					Success:             success,
-					Error:               msgIBCAcknowledgement.Params.MaybeFungibleTokenPacketData.MaybeError,
+					Error:               maybeError,
 					MessageType:         msgIBCAcknowledgement.MsgName,
 					Message:             msg,
 					UpdatedBondedTokens: updatedBondedTokensJSON,

--- a/projection/ibc_channel/view/ibc_channel_messages.go
+++ b/projection/ibc_channel/view/ibc_channel_messages.go
@@ -1,0 +1,77 @@
+package view
+
+import (
+	"fmt"
+
+	"github.com/crypto-com/chain-indexing/appinterface/rdb"
+)
+
+type IBCChannelMessages struct {
+	rdb *rdb.Handle
+}
+
+func NewIBCChannelMessages(handle *rdb.Handle) *IBCChannelMessages {
+	return &IBCChannelMessages{
+		handle,
+	}
+}
+
+func (ibcClientsView *IBCChannelMessages) Insert(ibcChannelMessage *IBCChannelMessageRow) error {
+	sql, sqlArgs, err := ibcClientsView.rdb.StmtBuilder.
+		Insert("view_ibc_channel_messages").
+		Columns(
+			"channel_id",
+			"block_height",
+			"source_channel",
+			"destination_channel",
+			"denom",
+			"amount",
+			"success",
+			"error",
+			"message_type",
+			"message",
+			"updated_bonded_tokens",
+		).
+		Values(
+			ibcChannelMessage.ChannelID,
+			ibcChannelMessage.BlockHeight,
+			ibcChannelMessage.SourceChannel,
+			ibcChannelMessage.DestinationChannel,
+			ibcChannelMessage.Denom,
+			ibcChannelMessage.Amount,
+			ibcChannelMessage.Success,
+			ibcChannelMessage.Error,
+			ibcChannelMessage.MessageType,
+			ibcChannelMessage.Message,
+			ibcChannelMessage.UpdatedBondedTokens,
+		).
+		ToSql()
+
+	if err != nil {
+		return fmt.Errorf("error building view_ibc_channel_messages insertion sql: %v: %w", err, rdb.ErrBuildSQLStmt)
+	}
+
+	result, err := ibcClientsView.rdb.Exec(sql, sqlArgs...)
+	if err != nil {
+		return fmt.Errorf("error inserting view_ibc_channel_messages into the table: %v: %w", err, rdb.ErrWrite)
+	}
+	if result.RowsAffected() != 1 {
+		return fmt.Errorf("error inserting view_ibc_channel_messages into the table: no row inserted: %w", rdb.ErrWrite)
+	}
+
+	return nil
+}
+
+type IBCChannelMessageRow struct {
+	ChannelID           string `json:"channelId"`
+	BlockHeight         int64  `json:"blockHeight"`
+	SourceChannel       string `json:"sourceChannel"`
+	DestinationChannel  string `json:"destinationChannel"`
+	Denom               string `json:"denom"`
+	Amount              string `json:"amount"`
+	Success             string `json:"success"`
+	Error               string `json:"error"`
+	MessageType         string `json:"messageType"`
+	Message             string `json:"message"`
+	UpdatedBondedTokens string `json:"updatedBondedTokens"`
+}

--- a/projection/ibc_channel/view/ibc_channel_messages.go
+++ b/projection/ibc_channel/view/ibc_channel_messages.go
@@ -16,8 +16,8 @@ func NewIBCChannelMessages(handle *rdb.Handle) *IBCChannelMessages {
 	}
 }
 
-func (ibcClientsView *IBCChannelMessages) Insert(ibcChannelMessage *IBCChannelMessageRow) error {
-	sql, sqlArgs, err := ibcClientsView.rdb.StmtBuilder.
+func (ibcChannelMessagesView *IBCChannelMessages) Insert(ibcChannelMessage *IBCChannelMessageRow) error {
+	sql, sqlArgs, err := ibcChannelMessagesView.rdb.StmtBuilder.
 		Insert("view_ibc_channel_messages").
 		Columns(
 			"channel_id",
@@ -51,7 +51,7 @@ func (ibcClientsView *IBCChannelMessages) Insert(ibcChannelMessage *IBCChannelMe
 		return fmt.Errorf("error building view_ibc_channel_messages insertion sql: %v: %w", err, rdb.ErrBuildSQLStmt)
 	}
 
-	result, err := ibcClientsView.rdb.Exec(sql, sqlArgs...)
+	result, err := ibcChannelMessagesView.rdb.Exec(sql, sqlArgs...)
 	if err != nil {
 		return fmt.Errorf("error inserting view_ibc_channel_messages into the table: %v: %w", err, rdb.ErrWrite)
 	}

--- a/projection/projections.go
+++ b/projection/projections.go
@@ -57,7 +57,13 @@ func InitProjection(name string, params InitParams) projection_entity.Projection
 			DropDataAccessor: "dropId",
 		})
 	case "IBCChannel":
-		return ibc_channel.NewIBCChannel(params.Logger, params.RdbConn)
+		return ibc_channel.NewIBCChannel(params.Logger, params.RdbConn, ibc_channel.Config{
+			EnableTxMsgTrace: false,
+		})
+	case "IBCChannelTxMsgTrace":
+		return ibc_channel.NewIBCChannel(params.Logger, params.RdbConn, ibc_channel.Config{
+			EnableTxMsgTrace: true,
+		})
 	// register more projections here
 	default:
 		panic(fmt.Sprintf("Unrecognized projection: %s", name))


### PR DESCRIPTION
Solution: fixed #509 

### How to enable?

In config file, use `IBCChannelTxMsgTrace` projection instead of `IBCChannel` projection.

### Added a new table `view_ibc_channel_message`

Table schema:
```
CREATE TABLE view_ibc_channel_messages (
    id BIGSERIAL,
    channel_id VARCHAR NOT NULL,
    block_height BIGINT NOT NULL,
    source_channel VARCHAR NOT NULL,
    destination_channel VARCHAR NOT NULL,
    denom VARCHAR NOT NULL,
    amount VARCHAR NOT NULL,
    success VARCHAR NOT NULL,
    error VARCHAR NOT NULL,
    message_type VARCHAR NOT NULL,
    message JSONB NOT NULL,
    updated_bonded_tokens JSONB NOT NULL,
    PRIMARY KEY(id)
);
```

