### PR TITLE
Problem: Missing IBC denom trace to hashed denom API

### DIFF
--- a/config/config.localnet.toml
+++ b/config/config.localnet.toml
@@ -77,6 +77,7 @@ enables = [
     "Validator",
     "ValidatorStats",
     "NFT",
-    "IBCChannel",
 #    "CryptoComNFT",
+    "IBCChannel",
+#    "IBCChannelTxMsgTrace",
 ]

--- a/config/config.mainnet.toml
+++ b/config/config.mainnet.toml
@@ -77,6 +77,7 @@ enables = [
     "Validator",
     "ValidatorStats",
     "NFT",
-    "IBCChannel",
 #    "CryptoComNFT",
+    "IBCChannel",
+#    "IBCChannelTxMsgTrace",
 ]

--- a/config/config.sample.toml
+++ b/config/config.sample.toml
@@ -77,6 +77,7 @@ enables = [
     "Validator",
     "ValidatorStats",
     "NFT",
-    "IBCChannel",
 #    "CryptoComNFT",
+    "IBCChannel",
+#    "IBCChannelTxMsgTrace",
 ]

--- a/config/config.testnet-3.toml
+++ b/config/config.testnet-3.toml
@@ -77,6 +77,7 @@ enables = [
     "Validator",
     "ValidatorStats",
     "NFT",
-    "IBCChannel",
 #    "CryptoComNFT",
+    "IBCChannel",
+#    "IBCChannelTxMsgTrace",
 ]

--- a/config/config.testnet-4.toml
+++ b/config/config.testnet-4.toml
@@ -77,6 +77,7 @@ enables = [
     "Validator",
     "ValidatorStats",
     "NFT",
-    "IBCChannel",
 #    "CryptoComNFT",
+    "IBCChannel",
+#    "IBCChannelTxMsgTrace",
 ]

--- a/config/config.testnet.toml
+++ b/config/config.testnet.toml
@@ -77,6 +77,7 @@ enables = [
     "Validator",
     "ValidatorStats",
     "NFT",
-    "IBCChannel",
 #    "CryptoComNFT",
+    "IBCChannel",
+#    "IBCChannelTxMsgTrace",
 ]

--- a/infrastructure/httpapi/handlers/ibc_channel.go
+++ b/infrastructure/httpapi/handlers/ibc_channel.go
@@ -15,7 +15,8 @@ import (
 type IBCChannel struct {
 	logger applogger.Logger
 
-	ibcChannelsView *ibc_channel_view.IBCChannels
+	ibcChannelsView         *ibc_channel_view.IBCChannels
+	ibcDenomHashMappingView *ibc_channel_view.IBCDenomHashMapping
 }
 
 func NewIBCChannel(logger applogger.Logger, rdbHandle *rdb.Handle) *IBCChannel {
@@ -25,6 +26,7 @@ func NewIBCChannel(logger applogger.Logger, rdbHandle *rdb.Handle) *IBCChannel {
 		}),
 
 		ibc_channel_view.NewIBCChannels(rdbHandle),
+		ibc_channel_view.NewIBCDenomHashMapping(rdbHandle),
 	}
 }
 
@@ -70,4 +72,15 @@ func (handler *IBCChannel) FindChannelById(ctx *fasthttp.RequestCtx) {
 	}
 
 	httpapi.Success(ctx, ibcChannel)
+}
+
+func (handler *IBCChannel) ListAllDenomHashMapping(ctx *fasthttp.RequestCtx) {
+	ibcDenomHashMappings, err := handler.ibcDenomHashMappingView.ListAll()
+	if err != nil {
+		handler.logger.Errorf("error listing IBCDenomHashMppings: %v", err)
+		httpapi.InternalServerError(ctx)
+		return
+	}
+
+	httpapi.Success(ctx, ibcDenomHashMappings)
 }

--- a/infrastructure/httpapi/routes/routes.go
+++ b/infrastructure/httpapi/routes/routes.go
@@ -111,4 +111,5 @@ func (registry *RouteRegistry) Register(server *httpapi.Server, routePrefix stri
 
 	server.GET(fmt.Sprintf("%s/api/v1/ibc/channels", routePrefix), registry.ibcChannelHandler.ListChannels)
 	server.GET(fmt.Sprintf("%s/api/v1/ibc/channels/{channelId}", routePrefix), registry.ibcChannelHandler.FindChannelById)
+	server.GET(fmt.Sprintf("%s/api/v1/ibc/denom-hash-mappings", routePrefix), registry.ibcChannelHandler.ListAllDenomHashMapping)
 }

--- a/migrations/20210830173217_view_ibc_channel_messages.down.sql
+++ b/migrations/20210830173217_view_ibc_channel_messages.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS view_ibc_channel_messages;

--- a/migrations/20210830173217_view_ibc_channel_messages.up.sql
+++ b/migrations/20210830173217_view_ibc_channel_messages.up.sql
@@ -1,0 +1,15 @@
+CREATE TABLE view_ibc_channel_messages (
+    id BIGSERIAL,
+    channel_id VARCHAR NOT NULL,
+    block_height BIGINT NOT NULL,
+    source_channel VARCHAR NOT NULL,
+    destination_channel VARCHAR NOT NULL,
+    denom VARCHAR NOT NULL,
+    amount VARCHAR NOT NULL,
+    success VARCHAR NOT NULL,
+    error VARCHAR NOT NULL,
+    message_type VARCHAR NOT NULL,
+    message JSONB NOT NULL,
+    updated_bonded_tokens JSONB NOT NULL,
+    PRIMARY KEY(id)
+);

--- a/migrations/20210902150815_view_ibc_denom_hash_mapping.down.sql
+++ b/migrations/20210902150815_view_ibc_denom_hash_mapping.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS view_ibc_denom_hash_mapping;

--- a/migrations/20210902150815_view_ibc_denom_hash_mapping.up.sql
+++ b/migrations/20210902150815_view_ibc_denom_hash_mapping.up.sql
@@ -1,0 +1,6 @@
+CREATE TABLE view_ibc_denom_hash_mapping (
+    id BIGSERIAL,
+    denom VARCHAR NOT NULL UNIQUE,
+    hash VARCHAR NOT NULL,
+    PRIMARY KEY(id)
+);

--- a/projection/ibc_channel/ibc_channel.go
+++ b/projection/ibc_channel/ibc_channel.go
@@ -562,7 +562,7 @@ func (projection *IBCChannel) updateBondedTokensWhenMsgIBCAcknowledgement(
 		// Add it to bondedTokens.OnCounterpartyChain
 		newDenom := fmt.Sprintf("%s/%s/%s", destinationPortID, destinationChannelID, denom)
 		token := ibc_channel_view.NewBondedToken(newDenom, amountInCoinInt)
-		projection.addOnCounterpartyChain(bondedTokens, token)
+		projection.addTokenOnCounterpartyChain(bondedTokens, token)
 	}
 
 	if err := ibcChannelsView.UpdateBondedTokens(channelID, bondedTokens); err != nil {
@@ -614,7 +614,7 @@ func (projection *IBCChannel) subtractTokenOnCounterpartyChain(
 	}
 }
 
-func (projection *IBCChannel) addOnCounterpartyChain(
+func (projection *IBCChannel) addTokenOnCounterpartyChain(
 	bondedTokens *ibc_channel_view.BondedTokens,
 	newToken *ibc_channel_view.BondedToken,
 ) {

--- a/projection/ibc_channel/ibc_channel.go
+++ b/projection/ibc_channel/ibc_channel.go
@@ -1,8 +1,11 @@
 package ibc_channel
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/crypto-com/chain-indexing/appinterface/projection/rdbprojectionbase"
 	"github.com/crypto-com/chain-indexing/appinterface/rdb"
@@ -86,6 +89,7 @@ func (projection *IBCChannel) HandleEvents(height int64, events []event_entity.E
 	ibcClientsView := ibc_channel_view.NewIBCClients(rdbTxHandle)
 	ibcConnectionsView := ibc_channel_view.NewIBCConnections(rdbTxHandle)
 	ibcChannelMessagesView := ibc_channel_view.NewIBCChannelMessages(rdbTxHandle)
+	ibcDenomHashMappingView := ibc_channel_view.NewIBCDenomHashMapping(rdbTxHandle)
 
 	// Get the block time of current height
 	var blockTime utctime.UTCTime
@@ -339,6 +343,7 @@ func (projection *IBCChannel) HandleEvents(height int64, events []event_entity.E
 
 				if err := projection.updateBondedTokensWhenMsgIBCRecvPacket(
 					ibcChannelsView,
+					ibcDenomHashMappingView,
 					channelID,
 					amount,
 					denom,
@@ -491,6 +496,7 @@ func (projection *IBCChannel) HandleEvents(height int64, events []event_entity.E
 
 func (projection *IBCChannel) updateBondedTokensWhenMsgIBCRecvPacket(
 	ibcChannelsView *ibc_channel_view.IBCChannels,
+	ibcDenomHashMappingView *ibc_channel_view.IBCDenomHashMapping,
 	channelID string,
 	amount uint64,
 	denom string,
@@ -516,6 +522,11 @@ func (projection *IBCChannel) updateBondedTokensWhenMsgIBCRecvPacket(
 		newDenom := fmt.Sprintf("%s/%s/%s", destinationPortID, destinationChannelID, denom)
 		token := ibc_channel_view.NewBondedToken(newDenom, amountInCoinInt)
 		projection.addTokenOnThisChain(bondedTokens, token)
+
+		// For keeping record of denom-hash, we only interested in tokens sending to our chain
+		if err = projection.insertDenomHashMappingIfNotExist(ibcDenomHashMappingView, newDenom); err != nil {
+			return fmt.Errorf("error insertDenomHashMappingIfNotExist: %w", err)
+		}
 	}
 
 	if err := ibcChannelsView.UpdateBondedTokens(channelID, bondedTokens); err != nil {
@@ -631,4 +642,29 @@ func (projection *IBCChannel) addTokenOnThisChain(
 	}
 	// This token has NO record on bondedTokens.OnThisChain yet
 	bondedTokens.OnThisChain = append(bondedTokens.OnThisChain, *newToken)
+}
+
+func (projection *IBCChannel) insertDenomHashMappingIfNotExist(
+	ibcDenomHashMappingView *ibc_channel_view.IBCDenomHashMapping,
+	denom string,
+) error {
+
+	exist, err := ibcDenomHashMappingView.IfDenomExist(denom)
+	if err != nil {
+		return fmt.Errorf("error invoking IfDenomExist(): %v", err)
+	}
+
+	// The record does not exist, insert one
+	if !exist {
+		sum := sha256.Sum256([]byte(denom))
+		hashBase64 := hex.EncodeToString((sum[:]))
+
+		return ibcDenomHashMappingView.Insert(&ibc_channel_view.IBCDenomHashMappingRow{
+			Denom: denom,
+			Hash:  strings.ToUpper(hashBase64),
+		})
+	}
+
+	// The record exists, do nothing
+	return nil
 }

--- a/projection/ibc_channel/view/ibc_channel_messages.go
+++ b/projection/ibc_channel/view/ibc_channel_messages.go
@@ -1,0 +1,77 @@
+package view
+
+import (
+	"fmt"
+
+	"github.com/crypto-com/chain-indexing/appinterface/rdb"
+)
+
+type IBCChannelMessages struct {
+	rdb *rdb.Handle
+}
+
+func NewIBCChannelMessages(handle *rdb.Handle) *IBCChannelMessages {
+	return &IBCChannelMessages{
+		handle,
+	}
+}
+
+func (ibcChannelMessagesView *IBCChannelMessages) Insert(ibcChannelMessage *IBCChannelMessageRow) error {
+	sql, sqlArgs, err := ibcChannelMessagesView.rdb.StmtBuilder.
+		Insert("view_ibc_channel_messages").
+		Columns(
+			"channel_id",
+			"block_height",
+			"source_channel",
+			"destination_channel",
+			"denom",
+			"amount",
+			"success",
+			"error",
+			"message_type",
+			"message",
+			"updated_bonded_tokens",
+		).
+		Values(
+			ibcChannelMessage.ChannelID,
+			ibcChannelMessage.BlockHeight,
+			ibcChannelMessage.SourceChannel,
+			ibcChannelMessage.DestinationChannel,
+			ibcChannelMessage.Denom,
+			ibcChannelMessage.Amount,
+			ibcChannelMessage.Success,
+			ibcChannelMessage.Error,
+			ibcChannelMessage.MessageType,
+			ibcChannelMessage.Message,
+			ibcChannelMessage.UpdatedBondedTokens,
+		).
+		ToSql()
+
+	if err != nil {
+		return fmt.Errorf("error building view_ibc_channel_messages insertion sql: %v: %w", err, rdb.ErrBuildSQLStmt)
+	}
+
+	result, err := ibcChannelMessagesView.rdb.Exec(sql, sqlArgs...)
+	if err != nil {
+		return fmt.Errorf("error inserting view_ibc_channel_messages into the table: %v: %w", err, rdb.ErrWrite)
+	}
+	if result.RowsAffected() != 1 {
+		return fmt.Errorf("error inserting view_ibc_channel_messages into the table: no row inserted: %w", rdb.ErrWrite)
+	}
+
+	return nil
+}
+
+type IBCChannelMessageRow struct {
+	ChannelID           string `json:"channelId"`
+	BlockHeight         int64  `json:"blockHeight"`
+	SourceChannel       string `json:"sourceChannel"`
+	DestinationChannel  string `json:"destinationChannel"`
+	Denom               string `json:"denom"`
+	Amount              string `json:"amount"`
+	Success             string `json:"success"`
+	Error               string `json:"error"`
+	MessageType         string `json:"messageType"`
+	Message             string `json:"message"`
+	UpdatedBondedTokens string `json:"updatedBondedTokens"`
+}

--- a/projection/ibc_channel/view/ibc_denom_hash_mapping.go
+++ b/projection/ibc_channel/view/ibc_denom_hash_mapping.go
@@ -1,0 +1,107 @@
+package view
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/crypto-com/chain-indexing/appinterface/rdb"
+)
+
+type IBCDenomHashMapping struct {
+	rdb *rdb.Handle
+}
+
+func NewIBCDenomHashMapping(handle *rdb.Handle) *IBCDenomHashMapping {
+	return &IBCDenomHashMapping{
+		handle,
+	}
+}
+
+func (ibcDenomHashMappingView *IBCDenomHashMapping) IfDenomExist(denom string) (bool, error) {
+	sql, sqlArgs, err := ibcDenomHashMappingView.rdb.StmtBuilder.
+		Select("COUNT(*)").
+		From("view_ibc_denom_hash_mapping").
+		Where("denom = ?", denom).
+		ToSql()
+	if err != nil {
+		return false, fmt.Errorf("error building count select view_ibc_denom_hash_mapping sql: %v: %w", err, rdb.ErrPrepare)
+	}
+
+	var count int64
+	if err = ibcDenomHashMappingView.rdb.QueryRow(sql, sqlArgs...).Scan(&count); err != nil {
+		return false, fmt.Errorf("error executing count select on view_ibc_denom_hash_mapping: %v: %w", err, rdb.ErrQuery)
+	}
+
+	return count > 0, nil
+}
+
+func (ibcDenomHashMappingView *IBCDenomHashMapping) Insert(ibcDenomHash *IBCDenomHashMappingRow) error {
+	sql, sqlArgs, err := ibcDenomHashMappingView.rdb.StmtBuilder.
+		Insert("view_ibc_denom_hash_mapping").
+		Columns(
+			"denom",
+			"hash",
+		).
+		Values(
+			ibcDenomHash.Denom,
+			ibcDenomHash.Hash,
+		).
+		ToSql()
+
+	if err != nil {
+		return fmt.Errorf("error building view_ibc_denom_hash_mapping insertion sql: %v: %w", err, rdb.ErrBuildSQLStmt)
+	}
+
+	result, err := ibcDenomHashMappingView.rdb.Exec(sql, sqlArgs...)
+	if err != nil {
+		return fmt.Errorf("error inserting view_ibc_denom_hash_mapping into the table: %v: %w", err, rdb.ErrWrite)
+	}
+	if result.RowsAffected() != 1 {
+		return fmt.Errorf("error inserting view_ibc_denom_hash_mapping into the table: no row inserted: %w", rdb.ErrWrite)
+	}
+
+	return nil
+}
+
+func (ibcDenomHashMappingView *IBCDenomHashMapping) ListAll() (*[]IBCDenomHashMappingRow, error) {
+	sql, sqlArgs, err := ibcDenomHashMappingView.rdb.StmtBuilder.Select(
+		"denom",
+		"hash",
+	).
+		From("view_ibc_denom_hash_mapping").
+		ToSql()
+	if err != nil {
+		return nil, fmt.Errorf("error building view_ibc_denom_hash_mapping select SQL: %v, %w", err, rdb.ErrBuildSQLStmt)
+	}
+
+	rowsResult, err := ibcDenomHashMappingView.rdb.Query(sql, sqlArgs...)
+	if err != nil {
+		return nil, fmt.Errorf("error executing view_ibc_denom_hash_mapping select SQL: %v: %w", err, rdb.ErrQuery)
+	}
+	defer rowsResult.Close()
+
+	denomHashMappings := make([]IBCDenomHashMappingRow, 0)
+	for rowsResult.Next() {
+		var denomHashRow IBCDenomHashMappingRow
+
+		if err = rowsResult.Scan(
+			&denomHashRow.Denom,
+			&denomHashRow.Hash,
+		); err != nil {
+			if errors.Is(err, rdb.ErrNoRows) {
+				return nil, rdb.ErrNoRows
+			}
+			return nil, fmt.Errorf("error scanning view_ibc_denom_hash_mapping row: %v: %w", err, rdb.ErrQuery)
+		}
+
+		denomHashMappings = append(denomHashMappings, denomHashRow)
+	}
+
+	return &denomHashMappings, nil
+}
+
+type IBCDenomHashMappingRow struct {
+	Denom string `json:"denom"`
+	// The hash should be a sha256 hex encoded string
+	Hash string `json:"hash"`
+}

--- a/projection/projections.go
+++ b/projection/projections.go
@@ -57,7 +57,13 @@ func InitProjection(name string, params InitParams) projection_entity.Projection
 			DropDataAccessor: "dropId",
 		})
 	case "IBCChannel":
-		return ibc_channel.NewIBCChannel(params.Logger, params.RdbConn)
+		return ibc_channel.NewIBCChannel(params.Logger, params.RdbConn, ibc_channel.Config{
+			EnableTxMsgTrace: false,
+		})
+	case "IBCChannelTxMsgTrace":
+		return ibc_channel.NewIBCChannel(params.Logger, params.RdbConn, ibc_channel.Config{
+			EnableTxMsgTrace: true,
+		})
 	// register more projections here
 	default:
 		panic(fmt.Sprintf("Unrecognized projection: %s", name))


### PR DESCRIPTION
Solution: fixed #490 

**This one is depended on PR #511 (ibc channel debug projection), please review that one first** 🙏 

### Changes

- Introduced a new table, which contain two columns `denom` and `hash`
- Added a new API to fetch all denom-hash mappings. `/ibc/denom-hash-mappings`

### Example API Response

```
{
    "result": [
        {
            "denom": "transfer/channel-0/solotoken",
            "hash": "1A35E932DCE61466ED9F72D0B436628C388FB1BC60CB23A055039B7DE54883CC"
        },
        {
            "denom": "transfer/channel-1/USDC",
            "hash": "C59CA0D4F324B119C79782232700A6920B2EACA776558D7319CFC36DEE5672BF"
        },
        {
            "denom": "transfer/channel-2/USDC",
            "hash": "21E9F91EE9AC1D7E2C3D002F4AA73CAAB61801B055FB6721D36F16BB890BE0A2"
        },
        {
            "denom": "transfer/channel-1/TEST",
            "hash": "96D929A2DDBAB720DA3AB084914A64D40920DCF8CCD06B32966FBAF3AE75BD24"
        },
        {
            "denom": "transfer/channel-2/TEST",
            "hash": "D6F89C93C2DA3753E81650E96153A2C3E6BCC781E42638AE7BE2635476E2B6BB"
        },
        {
            "denom": "transfer/channel-2/OTTER",
            "hash": "C63FD640F6213F1D23C2D28E73A7289E9524F8B6156107E40186834E27B1D3CE"
        }
    ]
}
```