### PR TITLE
Problem: Missing IBC denom trace to hashed denom API

### DIFF
--- a/infrastructure/httpapi/handlers/ibc_channel.go
+++ b/infrastructure/httpapi/handlers/ibc_channel.go
@@ -15,7 +15,8 @@ import (
 type IBCChannel struct {
 	logger applogger.Logger
 
-	ibcChannelsView *ibc_channel_view.IBCChannels
+	ibcChannelsView         *ibc_channel_view.IBCChannels
+	ibcDenomHashMappingView *ibc_channel_view.IBCDenomHashMapping
 }
 
 func NewIBCChannel(logger applogger.Logger, rdbHandle *rdb.Handle) *IBCChannel {
@@ -25,6 +26,7 @@ func NewIBCChannel(logger applogger.Logger, rdbHandle *rdb.Handle) *IBCChannel {
 		}),
 
 		ibc_channel_view.NewIBCChannels(rdbHandle),
+		ibc_channel_view.NewIBCDenomHashMapping(rdbHandle),
 	}
 }
 
@@ -70,4 +72,15 @@ func (handler *IBCChannel) FindChannelById(ctx *fasthttp.RequestCtx) {
 	}
 
 	httpapi.Success(ctx, ibcChannel)
+}
+
+func (handler *IBCChannel) ListAllDenomHashMapping(ctx *fasthttp.RequestCtx) {
+	ibcDenomHashMappings, err := handler.ibcDenomHashMappingView.ListAll()
+	if err != nil {
+		handler.logger.Errorf("error listing IBCDenomHashMppings: %v", err)
+		httpapi.InternalServerError(ctx)
+		return
+	}
+
+	httpapi.Success(ctx, ibcDenomHashMappings)
 }

--- a/infrastructure/httpapi/routes/routes.go
+++ b/infrastructure/httpapi/routes/routes.go
@@ -111,4 +111,5 @@ func (registry *RouteRegistry) Register(server *httpapi.Server, routePrefix stri
 
 	server.GET(fmt.Sprintf("%s/api/v1/ibc/channels", routePrefix), registry.ibcChannelHandler.ListChannels)
 	server.GET(fmt.Sprintf("%s/api/v1/ibc/channels/{channelId}", routePrefix), registry.ibcChannelHandler.FindChannelById)
+	server.GET(fmt.Sprintf("%s/api/v1/ibc/denom-hash-mappings", routePrefix), registry.ibcChannelHandler.ListAllDenomHashMapping)
 }

--- a/migrations/20210902150815_view_ibc_denom_hash_mapping.down.sql
+++ b/migrations/20210902150815_view_ibc_denom_hash_mapping.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS view_ibc_denom_hash_mapping;

--- a/migrations/20210902150815_view_ibc_denom_hash_mapping.up.sql
+++ b/migrations/20210902150815_view_ibc_denom_hash_mapping.up.sql
@@ -1,6 +1,6 @@
 CREATE TABLE view_ibc_denom_hash_mapping (
     id BIGSERIAL,
     denom VARCHAR NOT NULL UNIQUE,
-    hash VARCHAR NOT NULL,
+    hash VARCHAR NOT NULL UNIQUE,
     PRIMARY KEY(id)
 );

--- a/migrations/20210902150815_view_ibc_denom_hash_mapping.up.sql
+++ b/migrations/20210902150815_view_ibc_denom_hash_mapping.up.sql
@@ -1,0 +1,6 @@
+CREATE TABLE view_ibc_denom_hash_mapping (
+    id BIGSERIAL,
+    denom VARCHAR NOT NULL UNIQUE,
+    hash VARCHAR NOT NULL,
+    PRIMARY KEY(id)
+);

--- a/projection/ibc_channel/ibc_channel.go
+++ b/projection/ibc_channel/ibc_channel.go
@@ -1,8 +1,11 @@
 package ibc_channel
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/crypto-com/chain-indexing/appinterface/projection/rdbprojectionbase"
 	"github.com/crypto-com/chain-indexing/appinterface/rdb"
@@ -86,6 +89,7 @@ func (projection *IBCChannel) HandleEvents(height int64, events []event_entity.E
 	ibcClientsView := ibc_channel_view.NewIBCClients(rdbTxHandle)
 	ibcConnectionsView := ibc_channel_view.NewIBCConnections(rdbTxHandle)
 	ibcChannelMessagesView := ibc_channel_view.NewIBCChannelMessages(rdbTxHandle)
+	ibcDenomHashMappingView := ibc_channel_view.NewIBCDenomHashMapping(rdbTxHandle)
 
 	// Get the block time of current height
 	var blockTime utctime.UTCTime
@@ -351,6 +355,7 @@ func (projection *IBCChannel) HandleEvents(height int64, events []event_entity.E
 
 				if err := projection.updateBondedTokensWhenMsgIBCRecvPacket(
 					ibcChannelsView,
+					ibcDenomHashMappingView,
 					channelID,
 					amount,
 					denom,
@@ -503,6 +508,7 @@ func (projection *IBCChannel) HandleEvents(height int64, events []event_entity.E
 
 func (projection *IBCChannel) updateBondedTokensWhenMsgIBCRecvPacket(
 	ibcChannelsView *ibc_channel_view.IBCChannels,
+	ibcDenomHashMappingView *ibc_channel_view.IBCDenomHashMapping,
 	channelID string,
 	amount uint64,
 	denom string,
@@ -528,6 +534,11 @@ func (projection *IBCChannel) updateBondedTokensWhenMsgIBCRecvPacket(
 		newDenom := fmt.Sprintf("%s/%s/%s", destinationPortID, destinationChannelID, denom)
 		token := ibc_channel_view.NewBondedToken(newDenom, amountInCoinInt)
 		projection.addTokenOnThisChain(bondedTokens, token)
+
+		// For keeping record of denom-hash, we only interested in tokens sending to our chain
+		if err = projection.insertDenomHashMappingIfNotExist(ibcDenomHashMappingView, newDenom); err != nil {
+			return fmt.Errorf("error insertDenomHashMappingIfNotExist: %w", err)
+		}
 	}
 
 	if err := ibcChannelsView.UpdateBondedTokens(channelID, bondedTokens); err != nil {
@@ -643,4 +654,29 @@ func (projection *IBCChannel) addTokenOnThisChain(
 	}
 	// This token has NO record on bondedTokens.OnThisChain yet
 	bondedTokens.OnThisChain = append(bondedTokens.OnThisChain, *newToken)
+}
+
+func (projection *IBCChannel) insertDenomHashMappingIfNotExist(
+	ibcDenomHashMappingView *ibc_channel_view.IBCDenomHashMapping,
+	denom string,
+) error {
+
+	exist, err := ibcDenomHashMappingView.IfDenomExist(denom)
+	if err != nil {
+		return fmt.Errorf("error invoking IfDenomExist(): %v", err)
+	}
+
+	// The record does not exist, insert one
+	if !exist {
+		sum := sha256.Sum256([]byte(denom))
+		hashBase64 := hex.EncodeToString((sum[:]))
+
+		return ibcDenomHashMappingView.Insert(&ibc_channel_view.IBCDenomHashMappingRow{
+			Denom: denom,
+			Hash:  strings.ToUpper(hashBase64),
+		})
+	}
+
+	// The record exists, do nothing
+	return nil
 }

--- a/projection/ibc_channel/ibc_channel.go
+++ b/projection/ibc_channel/ibc_channel.go
@@ -574,7 +574,7 @@ func (projection *IBCChannel) updateBondedTokensWhenMsgIBCAcknowledgement(
 		// Add it to bondedTokens.OnCounterpartyChain
 		newDenom := fmt.Sprintf("%s/%s/%s", destinationPortID, destinationChannelID, denom)
 		token := ibc_channel_view.NewBondedToken(newDenom, amountInCoinInt)
-		projection.addOnCounterpartyChain(bondedTokens, token)
+		projection.addTokenOnCounterpartyChain(bondedTokens, token)
 	}
 
 	if err := ibcChannelsView.UpdateBondedTokens(channelID, bondedTokens); err != nil {
@@ -626,7 +626,7 @@ func (projection *IBCChannel) subtractTokenOnCounterpartyChain(
 	}
 }
 
-func (projection *IBCChannel) addOnCounterpartyChain(
+func (projection *IBCChannel) addTokenOnCounterpartyChain(
 	bondedTokens *ibc_channel_view.BondedTokens,
 	newToken *ibc_channel_view.BondedToken,
 ) {

--- a/projection/ibc_channel/ibc_channel.go
+++ b/projection/ibc_channel/ibc_channel.go
@@ -104,10 +104,22 @@ func (projection *IBCChannel) HandleEvents(height int64, events []event_entity.E
 
 	for _, event := range events {
 		if msgIBCCreateClient, ok := event.(*event_usecase.MsgIBCCreateClient); ok {
-
-			client := &ibc_channel_view.IBCClientRow{
-				ClientID:            msgIBCCreateClient.Params.ClientID,
-				CounterpartyChainID: msgIBCCreateClient.Params.MaybeTendermintLightClient.TendermintClientState.ChainID,
+			var client *ibc_channel_view.IBCClientRow
+			if msgIBCCreateClient.Params.MaybeTendermintLightClient != nil {
+				client = &ibc_channel_view.IBCClientRow{
+					ClientID:            msgIBCCreateClient.Params.ClientID,
+					CounterpartyChainID: msgIBCCreateClient.Params.MaybeTendermintLightClient.TendermintClientState.ChainID,
+				}
+			} else if msgIBCCreateClient.Params.MaybeSoloMachineLightClient != nil {
+				client = &ibc_channel_view.IBCClientRow{
+					ClientID:            msgIBCCreateClient.Params.ClientID,
+					CounterpartyChainID: msgIBCCreateClient.Params.MaybeSoloMachineLightClient.SoloMachineLightClientConsensusState.Diversifier,
+				}
+			} else if msgIBCCreateClient.Params.MaybeLocalhostLightClient != nil {
+				client = &ibc_channel_view.IBCClientRow{
+					ClientID:            msgIBCCreateClient.Params.ClientID,
+					CounterpartyChainID: msgIBCCreateClient.Params.MaybeLocalhostLightClient.LocalhostClientState.ChainID,
+				}
 			}
 			if err := ibcClientsView.Insert(client); err != nil {
 				return fmt.Errorf("error inserting client: %w", err)

--- a/projection/ibc_channel/view/ibc_denom_hash_mapping.go
+++ b/projection/ibc_channel/view/ibc_denom_hash_mapping.go
@@ -1,0 +1,107 @@
+package view
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/crypto-com/chain-indexing/appinterface/rdb"
+)
+
+type IBCDenomHashMapping struct {
+	rdb *rdb.Handle
+}
+
+func NewIBCDenomHashMapping(handle *rdb.Handle) *IBCDenomHashMapping {
+	return &IBCDenomHashMapping{
+		handle,
+	}
+}
+
+func (ibcDenomHashMappingView *IBCDenomHashMapping) IfDenomExist(denom string) (bool, error) {
+	sql, sqlArgs, err := ibcDenomHashMappingView.rdb.StmtBuilder.
+		Select("COUNT(*)").
+		From("view_ibc_denom_hash_mapping").
+		Where("denom = ?", denom).
+		ToSql()
+	if err != nil {
+		return false, fmt.Errorf("error building count select view_ibc_denom_hash_mapping sql: %v: %w", err, rdb.ErrPrepare)
+	}
+
+	var count int64
+	if err = ibcDenomHashMappingView.rdb.QueryRow(sql, sqlArgs...).Scan(&count); err != nil {
+		return false, fmt.Errorf("error executing count select on view_ibc_denom_hash_mapping: %v: %w", err, rdb.ErrQuery)
+	}
+
+	return count > 0, nil
+}
+
+func (ibcDenomHashMappingView *IBCDenomHashMapping) Insert(ibcDenomHash *IBCDenomHashMappingRow) error {
+	sql, sqlArgs, err := ibcDenomHashMappingView.rdb.StmtBuilder.
+		Insert("view_ibc_denom_hash_mapping").
+		Columns(
+			"denom",
+			"hash",
+		).
+		Values(
+			ibcDenomHash.Denom,
+			ibcDenomHash.Hash,
+		).
+		ToSql()
+
+	if err != nil {
+		return fmt.Errorf("error building view_ibc_denom_hash_mapping insertion sql: %v: %w", err, rdb.ErrBuildSQLStmt)
+	}
+
+	result, err := ibcDenomHashMappingView.rdb.Exec(sql, sqlArgs...)
+	if err != nil {
+		return fmt.Errorf("error inserting view_ibc_denom_hash_mapping into the table: %v: %w", err, rdb.ErrWrite)
+	}
+	if result.RowsAffected() != 1 {
+		return fmt.Errorf("error inserting view_ibc_denom_hash_mapping into the table: no row inserted: %w", rdb.ErrWrite)
+	}
+
+	return nil
+}
+
+func (ibcDenomHashMappingView *IBCDenomHashMapping) ListAll() (*[]IBCDenomHashMappingRow, error) {
+	sql, sqlArgs, err := ibcDenomHashMappingView.rdb.StmtBuilder.Select(
+		"denom",
+		"hash",
+	).
+		From("view_ibc_denom_hash_mapping").
+		ToSql()
+	if err != nil {
+		return nil, fmt.Errorf("error building view_ibc_denom_hash_mapping select SQL: %v, %w", err, rdb.ErrBuildSQLStmt)
+	}
+
+	rowsResult, err := ibcDenomHashMappingView.rdb.Query(sql, sqlArgs...)
+	if err != nil {
+		return nil, fmt.Errorf("error executing view_ibc_denom_hash_mapping select SQL: %v: %w", err, rdb.ErrQuery)
+	}
+	defer rowsResult.Close()
+
+	denomHashMappings := make([]IBCDenomHashMappingRow, 0)
+	for rowsResult.Next() {
+		var denomHashRow IBCDenomHashMappingRow
+
+		if err = rowsResult.Scan(
+			&denomHashRow.Denom,
+			&denomHashRow.Hash,
+		); err != nil {
+			if errors.Is(err, rdb.ErrNoRows) {
+				return nil, rdb.ErrNoRows
+			}
+			return nil, fmt.Errorf("error scanning view_ibc_denom_hash_mapping row: %v: %w", err, rdb.ErrQuery)
+		}
+
+		denomHashMappings = append(denomHashMappings, denomHashRow)
+	}
+
+	return &denomHashMappings, nil
+}
+
+type IBCDenomHashMappingRow struct {
+	Denom string `json:"denom"`
+	// The hash should be a sha256 hex encoded string
+	Hash string `json:"hash"`
+}

--- a/usecase/model/ibc/localhost.go
+++ b/usecase/model/ibc/localhost.go
@@ -1,0 +1,11 @@
+package ibc
+
+type LocalhostLightClientState struct {
+	Type    string                          `mapstructure:"@type" json:"@type"`
+	ChainID string                          `mapstructure:"chain_id" json:"chainId"`
+	Height  LocalhostLightClientStateHeight `mapstructure:"height" json:"height"`
+}
+type LocalhostLightClientStateHeight struct {
+	RevisionNumber uint64 `mapstructure:"revision_number" json:"revisionNumber,string"`
+	RevisionHeight uint64 `mapstructure:"revision_height" json:"revisionHeight,string"`
+}

--- a/usecase/model/ibc/msg_create_client.go
+++ b/usecase/model/ibc/msg_create_client.go
@@ -1,8 +1,10 @@
 package ibc
 
 type MsgCreateClientParams struct {
-	MaybeTendermintLightClient *TendermintLightClient `json:"maybeTendermintLightClient"`
-	// TODO: SoloMachine and Localhost LightClient
+	MaybeTendermintLightClient  *TendermintLightClient  `json:"maybeTendermintLightClient"`
+	MaybeSoloMachineLightClient *SoloMachineLightClient `json:"maybeSoloMachineLightClient"`
+	MaybeLocalhostLightClient   *LocalhostLightClient   `json:"maybeLocalhostLightClient"`
+	// TODO: Test localhost LightClient
 	Signer string `json:"signer"`
 
 	ClientID   string `json:"clientId"`
@@ -14,9 +16,31 @@ type TendermintLightClient struct {
 	TendermintLightClientConsensusState TendermintLightClientConsensusState `json:"consensusState"`
 }
 
+type SoloMachineLightClient struct {
+	SoloMachineClientState               SoloMachineLightClientState          `json:"clientState"`
+	SoloMachineLightClientConsensusState SoloMachineLightClientConsensusState `json:"consensusState"`
+}
+
+type LocalhostLightClient struct {
+	LocalhostClientState LocalhostLightClientState `json:"clientState"`
+}
+
 type RawMsgCreateTendermintLightClient struct {
 	Type           string                              `mapstructure:"@type" json:"@type"`
 	ClientState    TendermintLightClientState          `mapstructure:"client_state" json:"clientState"`
 	ConsensusState TendermintLightClientConsensusState `mapstructure:"consensus_state" json:"consensusState"`
 	Signer         string                              `mapstructure:"signer" json:"signer"`
+}
+
+type RawMsgCreateSoloMachineLightClient struct {
+	Type           string                               `mapstructure:"@type" json:"@type"`
+	ClientState    SoloMachineLightClientState          `mapstructure:"client_state" json:"clientState"`
+	ConsensusState SoloMachineLightClientConsensusState `mapstructure:"consensus_state" json:"consensusState"`
+	Signer         string                               `mapstructure:"signer" json:"signer"`
+}
+
+type RawMsgCreateLocalhostLightClient struct {
+	Type        string                    `mapstructure:"@type" json:"@type"`
+	ClientState LocalhostLightClientState `mapstructure:"client_state" json:"clientState"`
+	Signer      string                    `mapstructure:"signer" json:"signer"`
 }

--- a/usecase/model/ibc/msg_update_client.go
+++ b/usecase/model/ibc/msg_update_client.go
@@ -3,8 +3,9 @@ package ibc
 import "time"
 
 type MsgUpdateClientParams struct {
-	MaybeTendermintLightClientUpdate *TendermintLightClientUpdate `json:"maybeTendermintLightClientUpdate"`
-	// TODO: SoloMachine and Localhost LightClient
+	MaybeTendermintLightClientUpdate  *TendermintLightClientUpdate  `json:"maybeTendermintLightClientUpdate"`
+	MaybeSoloMachineLightClientUpdate *SoloMachineLightClientUpdate `json:"maybeSoloMachineLightClientUpdate"`
+	// TODO: Localhost LightClient
 
 	ClientID        string `json:"clientId"`
 	ClientType      string `json:"clientType"`
@@ -16,11 +17,22 @@ type TendermintLightClientUpdate struct {
 	Header TendermintLightClientHeader `json:"header"`
 }
 
+type SoloMachineLightClientUpdate struct {
+	Header SoloMachineLightClientHeader `json:"header"`
+}
+
 type RawMsgUpdateTendermintLightClient struct {
 	Type     string                      `mapstructure:"@type" json:"@type"`
 	ClientID string                      `mapstructure:"client_id" json:"clientId"`
 	Header   TendermintLightClientHeader `mapstructure:"header" json:"header"`
 	Signer   string                      `mapstructure:"signer" json:"signer"`
+}
+
+type RawMsgUpdateSoloMachineLightClient struct {
+	Type     string                       `mapstructure:"@type" json:"@type"`
+	ClientID string                       `mapstructure:"client_id" json:"clientId"`
+	Header   SoloMachineLightClientHeader `mapstructure:"header" json:"header"`
+	Signer   string                       `mapstructure:"signer" json:"signer"`
 }
 
 type TendermintLightClientHeader struct {
@@ -103,4 +115,18 @@ type TendermintLightClientProposer struct {
 type TendermintLightClientPubKey struct {
 	MaybeEd25519   []byte `mapstructure:"ed25519" json:"ed25519,omitempty"`
 	MaybeSecp256K1 []byte `mapstructure:"secp256k1" json:"secp256k1,omitempty"`
+}
+
+type SoloMachineLightClientHeader struct {
+	Type           string                       `mapstructure:"@type" json:"@type"`
+	Sequence       uint64                       `mapstructure:"sequence" json:"sequence"`
+	Timestamp      uint64                       `mapstructure:"timestamp" json:"timestamp"`
+	Signature      []byte                       `mapstructure:"signature" json:"signature"`
+	NewPublicKey   SoloMachineLightClientPubKey `mapstructure:"new_public_key" json:"newPublicKey"`
+	NewDiversifier string                       `mapstructure:"new_diversifier" json:"NewDiversifier"`
+}
+
+type SoloMachineLightClientPubKey struct {
+	Type string `mapstructure:"@type" json:"@type"`
+	Key  string `mapstructure:"key" json:"key"`
 }

--- a/usecase/model/ibc/solomachine.go
+++ b/usecase/model/ibc/solomachine.go
@@ -1,0 +1,19 @@
+package ibc
+
+type SoloMachineLightClientState struct {
+	Type                     string `mapstructure:"@type" json:"@type"`
+	Sequence                 uint64 `mapstructure:"sequence" json:"sequence"`
+	IsFrozen                 bool   `mapstructure:"is_frozen" json:"isFrozen"`
+	AllowUpdateAfterProposal bool   `mapstructure:"allowUpdate_after_proposal" json:"allowUpdateAfterProposal"`
+}
+
+type SoloMachineLightClientConsensusState struct {
+	PublicKey   SoloMachineLightClientConsensusStatePublicKey `mapstructure:"public_key" json:"publicKey"`
+	Diversifier string                                        `mapstructure:"diversifier" json:"diversifier"`
+	Timestamp   uint64                                        `mapstructure:"timestamp" json:"timestamp"`
+}
+
+type SoloMachineLightClientConsensusStatePublicKey struct {
+	Type string `mapstructure:"@type" json:"@type"`
+	Key  string `mapstructure:"key" json:"key"`
+}

--- a/usecase/parser/msg.go
+++ b/usecase/parser/msg.go
@@ -152,6 +152,8 @@ func ParseBlockResultsTxsMsgToCommands(
 				// TODO: implement MsgGrantAllowance parser
 			case "/cosmos.feegrant.v1beta1.MsgRevokeAllowance":
 				// TODO: implement MsgRevokeAllowance parser
+			case "/cosmos.vesting.v1beta1.MsgCreateVestingAccount":
+				// TODO: implement MsgCreateVestingAccount parser
 			}
 
 			commands = append(commands, msgCommands...)

--- a/usecase/parser/msg_ibc_create_solomachine_client_test.go
+++ b/usecase/parser/msg_ibc_create_solomachine_client_test.go
@@ -1,0 +1,93 @@
+package parser_test
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/crypto-com/chain-indexing/internal/json"
+
+	"github.com/crypto-com/chain-indexing/usecase/parser/utils"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/crypto-com/chain-indexing/infrastructure/tendermint"
+	"github.com/crypto-com/chain-indexing/usecase/event"
+	"github.com/crypto-com/chain-indexing/usecase/parser"
+	usecase_parser_test "github.com/crypto-com/chain-indexing/usecase/parser/test"
+)
+
+var _ = Describe("ParseMsgCommands", func() {
+	Describe("MsgIBCCreateSolomachineClient", func() {
+		It("should parse Msg commands when there is MsgCreateClient in the transaction", func() {
+			expected := `{
+            "name": "MsgCreateClientCreated",
+            "version": 1,
+            "height": 14791,
+            "uuid": "{UUID}",
+            "msgName": "MsgCreateClient",
+            "txHash": "0DB632201805BC399035F0B0CD0E1DABC061E5209D8A709EC0A2B29B1A306BA5",
+            "msgIndex": 0,
+            "params": {
+                "maybeTendermintLightClient": null,
+                "maybeSoloMachineLightClient": {
+                    "clientState": {
+                        "@type": "/ibc.lightclients.solomachine.v2.ClientState",
+                        "sequence": 1,
+                        "isFrozen": false,
+                        "allowUpdateAfterProposal": false
+                    },
+                    "consensusState": {
+                        "publicKey": {
+                            "@type": "/cosmos.crypto.secp256k1.PubKey",
+                            "key": "Ausp3XCdeFAWXHNeTBb3JZY56fMncZ/tpRnGfSFVdESm"
+                        },
+                        "diversifier": "solo-machine-diversifier",
+                        "timestamp": 1629427754
+                    }
+                },
+                "maybeLocalhostLightClient": null,
+                "signer": "tcro14wku4hr74m0m4tvexs4f6jvuy6vnu2x2dg7hsy",
+                "clientId": "06-solomachine-0",
+                "clientType": "06-solomachine"
+            }
+        }`
+
+			txDecoder := utils.NewTxDecoder()
+			block, _, _ := tendermint.ParseBlockResp(strings.NewReader(
+				usecase_parser_test.TX_MSG_CREATE_SOLOMACHINE_CLIENT_BLOCK_RESP,
+			))
+			blockResults, _ := tendermint.ParseBlockResultsResp(strings.NewReader(
+				usecase_parser_test.TX_MSG_CREATE_SOLOMACHINE_CLIENT_BLOCK_RESULTS_RESP,
+			))
+
+			accountAddressPrefix := "cro"
+			stakingDenom := "basecro"
+			cmds, err := parser.ParseBlockResultsTxsMsgToCommands(
+				txDecoder,
+				block,
+				blockResults,
+				accountAddressPrefix,
+				stakingDenom,
+			)
+			Expect(err).To(BeNil())
+			Expect(cmds).To(HaveLen(1))
+			cmd := cmds[0]
+			Expect(cmd.Name()).To(Equal("CreateMsgIBCCreateClient"))
+
+			untypedEvent, _ := cmd.Exec()
+			createMsgCreateClientEvent := untypedEvent.(*event.MsgIBCCreateClient)
+
+			regex, _ := regexp.Compile("\n?\r?\\s?")
+
+			Expect(json.MustMarshalToString(createMsgCreateClientEvent)).To(Equal(
+				strings.Replace(
+					regex.ReplaceAllString(expected, ""),
+					"{UUID}",
+					createMsgCreateClientEvent.UUID(),
+					-1,
+				),
+			))
+		})
+	})
+})

--- a/usecase/parser/msg_ibc_create_tendermint_client_test.go
+++ b/usecase/parser/msg_ibc_create_tendermint_client_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 var _ = Describe("ParseMsgCommands", func() {
-	Describe("MsgIBCCreateClient", func() {
+	Describe("MsgIBCCreateTendermintClient", func() {
 		It("should parse Msg commands when there is MsgCreateClient in the transaction", func() {
 			expected := `{
   "name": "MsgCreateClientCreated",
@@ -90,6 +90,8 @@ var _ = Describe("ParseMsgCommands", func() {
 		  "nextValidatorsHash": "E3DE0D2B3237A02E9C20C34F9EE04F69F5861FBC2E2722A011CA9037FC67A7EC"
 		}
 	  },
+      "maybeSoloMachineLightClient": null,
+      "maybeLocalhostLightClient": null,
 	  "signer": "cro1gdswrmwtzgv3kvf28lvtt7qv7q7myzmn466r3f",
 	  "clientId": "07-tendermint-0",
 	  "clientType": "07-tendermint"
@@ -98,10 +100,10 @@ var _ = Describe("ParseMsgCommands", func() {
 
 			txDecoder := utils.NewTxDecoder()
 			block, _, _ := tendermint.ParseBlockResp(strings.NewReader(
-				usecase_parser_test.TX_MSG_CREATE_CLIENT_BLOCK_RESP,
+				usecase_parser_test.TX_MSG_CREATE_TENDERMINT_CLIENT_BLOCK_RESP,
 			))
 			blockResults, _ := tendermint.ParseBlockResultsResp(strings.NewReader(
-				usecase_parser_test.TX_MSG_CREATE_CLIENT_BLOCK_RESULTS_RESP,
+				usecase_parser_test.TX_MSG_CREATE_TENDERMINT_CLIENT_BLOCK_RESULTS_RESP,
 			))
 
 			accountAddressPrefix := "cro"

--- a/usecase/parser/msg_ibc_update_tendermint_client_test.go
+++ b/usecase/parser/msg_ibc_update_tendermint_client_test.go
@@ -126,6 +126,7 @@ var _ = Describe("ParseMsgCommands", func() {
         }
       }
     },
+    "maybeSoloMachineLightClientUpdate":null,
     "clientId": "07-tendermint-0",
     "clientType": "07-tendermint",
     "consensusHeight": {
@@ -138,10 +139,10 @@ var _ = Describe("ParseMsgCommands", func() {
 
 			txDecoder := utils.NewTxDecoder()
 			block, _, _ := tendermint.ParseBlockResp(strings.NewReader(
-				usecase_parser_test.TX_MSG_UPDATE_CLIENT_BLOCK_RESP,
+				usecase_parser_test.TX_MSG_UPDATE_TENDERMINT_CLIENT_BLOCK_RESP,
 			))
 			blockResults, _ := tendermint.ParseBlockResultsResp(strings.NewReader(
-				usecase_parser_test.TX_MSG_UPDATE_CLIENT_BLOCK_RESULTS_RESP,
+				usecase_parser_test.TX_MSG_UPDATE_TENDERMINT_CLIENT_BLOCK_RESULTS_RESP,
 			))
 
 			accountAddressPrefix := "cro"

--- a/usecase/parser/test/tx_msg_ibc_create_solomachine_client.go
+++ b/usecase/parser/test/tx_msg_ibc_create_solomachine_client.go
@@ -1,0 +1,589 @@
+package usecase_parser_test
+
+const TX_MSG_CREATE_SOLOMACHINE_CLIENT_BLOCK_RESP = `{
+  "jsonrpc": "2.0",
+  "id": -1,
+  "result": {
+    "block_id": {
+      "hash": "B147388BB1E0D1FE5ABDD5820D1137C887B8FCC0C6A648799259C31867E8B816",
+      "parts": {
+        "total": 1,
+        "hash": "4DEAB75CA344C466ADEEEEBC9180BB5C261BC4FB8893F8182576990FF927F2CE"
+      }
+    },
+    "block": {
+      "header": {
+        "version": {
+          "block": "11"
+        },
+        "chain_id": "testnet-croeseid-4",
+        "height": "14791",
+        "time": "2021-08-20T02:49:21.578863734Z",
+        "last_block_id": {
+          "hash": "96068C0A0D2EC7EE28F1C3D30707623D0E6AB4EDD16382402796336208D19AEB",
+          "parts": {
+            "total": 1,
+            "hash": "EA8F35958282FA026C0F54297C61616CC7BACCF6D7B0B8794F4AE50D5D66D803"
+          }
+        },
+        "last_commit_hash": "0A15AEB9A5045C595C898D0C3E13909AEC2BC7CEB0DF3BA1D44F2B6F54E0BFA8",
+        "data_hash": "337DAE7557BDFF199D98449FEBDEC21832EE656B378C89FA7A59F8B937D70179",
+        "validators_hash": "856C3B06E9040E535C3E1D46B2863876FAF1F001E7B7D1C70C0BA571A737E0C9",
+        "next_validators_hash": "856C3B06E9040E535C3E1D46B2863876FAF1F001E7B7D1C70C0BA571A737E0C9",
+        "consensus_hash": "372B4AE845086C837EFEF79A189B085B1FD6610C53F3BEB17EE0E27B347C06DE",
+        "app_hash": "69B504EF011137526AD994981108C522BBFBD9071D59BCE35A013CB8C67273B6",
+        "last_results_hash": "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
+        "evidence_hash": "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
+        "proposer_address": "71DA178AE52B2D0654102A86166CE91AC5121CB2"
+      },
+      "data": {
+        "txs": [
+          "CqoDCpQDCiMvaWJjLmNvcmUuY2xpZW50LnYxLk1zZ0NyZWF0ZUNsaWVudBLsAgqeAQosL2liYy5saWdodGNsaWVudHMuc29sb21hY2hpbmUudjIuQ2xpZW50U3RhdGUSbggBGmgKRgofL2Nvc21vcy5jcnlwdG8uc2VjcDI1NmsxLlB1YktleRIjCiEC6yndcJ14UBZcc15MFvclljnp8ydxn+2lGcZ9IVV0RKYSGHNvbG8tbWFjaGluZS1kaXZlcnNpZmllchiqsPyIBiABEpsBCi8vaWJjLmxpZ2h0Y2xpZW50cy5zb2xvbWFjaGluZS52Mi5Db25zZW5zdXNTdGF0ZRJoCkYKHy9jb3Ntb3MuY3J5cHRvLnNlY3AyNTZrMS5QdWJLZXkSIwohAusp3XCdeFAWXHNeTBb3JZY56fMncZ/tpRnGfSFVdESmEhhzb2xvLW1hY2hpbmUtZGl2ZXJzaWZpZXIYqrD8iAYaK3Rjcm8xNHdrdTRocjc0bTBtNHR2ZXhzNGY2anZ1eTZ2bnUyeDJkZzdoc3kSEXNvbG8tbWFjaGluZS1tZW1vEmkKTgpGCh8vY29zbW9zLmNyeXB0by5zZWNwMjU2azEuUHViS2V5EiMKIQLrKd1wnXhQFlxzXkwW9yWWOenzJ3Gf7aUZxn0hVXREphIECgIIARIXChEKCGJhc2V0Y3JvEgUxMDAwMBDgpxIaQKUFo8cobjRAe3tvtvj4OkkNoiKgduqPfb1kuMJQAQ8zU8589A4TEXUBFVM6On0XzS0/S43boiY52lUSp20EvV8="
+        ]
+      },
+      "evidence": {
+        "evidence": []
+      },
+      "last_commit": {
+        "height": "14790",
+        "round": 0,
+        "block_id": {
+          "hash": "96068C0A0D2EC7EE28F1C3D30707623D0E6AB4EDD16382402796336208D19AEB",
+          "parts": {
+            "total": 1,
+            "hash": "EA8F35958282FA026C0F54297C61616CC7BACCF6D7B0B8794F4AE50D5D66D803"
+          }
+        },
+        "signatures": [
+          {
+            "block_id_flag": 2,
+            "validator_address": "71DA178AE52B2D0654102A86166CE91AC5121CB2",
+            "timestamp": "2021-08-20T02:49:21.611930663Z",
+            "signature": "A7QiugCxXqMEZzu7Dk5baylyFQP5LKN7ynBV43JQO62GxZKpGAceSTpGSOM1CN1W2LNrAFcvdKN4FBVCHKDECw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "7E2B455523A35AE8F4064C00AF01515FEF673079",
+            "timestamp": "2021-08-20T02:49:21.578863734Z",
+            "signature": "yeHvvZeSrQgsxmLotELOBtpRUjWhVqUwv8VmDoXbwy66d6Wye34Z5fPPhy+wiEAyh0CC1AKUsmEn4X63b+/yCw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "F9A4582896E5F2692BEDDD7C251755E33D2DE013",
+            "timestamp": "2021-08-20T02:49:21.573351718Z",
+            "signature": "KaelkJqSKi+oHdhEz438ongc94LRgllC5wZ79Bdx3gThbK02CY0psFf9F499j1L0IjOG8lSgdWJJa850y0C9AQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "19982846C26E6C39745F85FFCEA9950895563EE1",
+            "timestamp": "2021-08-20T02:49:21.736717Z",
+            "signature": "39uboeTmZrn2ljkS5dbKGuvYcc/OGkT7PElpb4chyKQGe9s5fl4GaZvH/CdKwYEAzS2vDd+ieyEPxWnh6VGzDQ=="
+          }
+        ]
+      }
+    }
+  }
+}`
+
+const TX_MSG_CREATE_SOLOMACHINE_CLIENT_BLOCK_RESULTS_RESP = `
+{
+  "jsonrpc": "2.0",
+  "id": -1,
+  "result": {
+    "height": "14791",
+    "txs_results": [
+      {
+        "code": 0,
+        "data": "CiUKIy9pYmMuY29yZS5jbGllbnQudjEuTXNnQ3JlYXRlQ2xpZW50",
+        "log": "[{\"events\":[{\"type\":\"create_client\",\"attributes\":[{\"key\":\"client_id\",\"value\":\"06-solomachine-0\"},{\"key\":\"client_type\",\"value\":\"06-solomachine\"},{\"key\":\"consensus_height\",\"value\":\"0-1\"}]},{\"type\":\"message\",\"attributes\":[{\"key\":\"action\",\"value\":\"/ibc.core.client.v1.MsgCreateClient\"},{\"key\":\"module\",\"value\":\"ibc_client\"}]}]}]",
+        "info": "",
+        "gas_wanted": "300000",
+        "gas_used": "76405",
+        "events": [
+          {
+            "type": "coin_spent",
+            "attributes": [
+              {
+                "key": "c3BlbmRlcg==",
+                "value": "dGNybzE0d2t1NGhyNzRtMG00dHZleHM0ZjZqdnV5NnZudTJ4MmRnN2hzeQ==",
+                "index": true
+              },
+              {
+                "key": "YW1vdW50",
+                "value": "MTAwMDBiYXNldGNybw==",
+                "index": true
+              }
+            ]
+          },
+          {
+            "type": "coin_received",
+            "attributes": [
+              {
+                "key": "cmVjZWl2ZXI=",
+                "value": "dGNybzE3eHBmdmFrbTJhbWc5NjJ5bHM2Zjg0ejNrZWxsOGM1bHhoemFoYQ==",
+                "index": true
+              },
+              {
+                "key": "YW1vdW50",
+                "value": "MTAwMDBiYXNldGNybw==",
+                "index": true
+              }
+            ]
+          },
+          {
+            "type": "transfer",
+            "attributes": [
+              {
+                "key": "cmVjaXBpZW50",
+                "value": "dGNybzE3eHBmdmFrbTJhbWc5NjJ5bHM2Zjg0ejNrZWxsOGM1bHhoemFoYQ==",
+                "index": true
+              },
+              {
+                "key": "c2VuZGVy",
+                "value": "dGNybzE0d2t1NGhyNzRtMG00dHZleHM0ZjZqdnV5NnZudTJ4MmRnN2hzeQ==",
+                "index": true
+              },
+              {
+                "key": "YW1vdW50",
+                "value": "MTAwMDBiYXNldGNybw==",
+                "index": true
+              }
+            ]
+          },
+          {
+            "type": "message",
+            "attributes": [
+              {
+                "key": "c2VuZGVy",
+                "value": "dGNybzE0d2t1NGhyNzRtMG00dHZleHM0ZjZqdnV5NnZudTJ4MmRnN2hzeQ==",
+                "index": true
+              }
+            ]
+          },
+          {
+            "type": "tx",
+            "attributes": [
+              {
+                "key": "YWNjX3NlcQ==",
+                "value": "dGNybzE0d2t1NGhyNzRtMG00dHZleHM0ZjZqdnV5NnZudTJ4MmRnN2hzeS8w",
+                "index": true
+              }
+            ]
+          },
+          {
+            "type": "tx",
+            "attributes": [
+              {
+                "key": "c2lnbmF0dXJl",
+                "value": "cFFXanh5aHVORUI3ZTIrMitQZzZTUTJpSXFCMjZvOTl2V1M0d2xBQkR6TlR6bnowRGhNUmRRRVZVem82ZlJmTkxUOUxqZHVpSmpuYVZSS25iUVM5WHc9PQ==",
+                "index": true
+              }
+            ]
+          },
+          {
+            "type": "message",
+            "attributes": [
+              {
+                "key": "YWN0aW9u",
+                "value": "L2liYy5jb3JlLmNsaWVudC52MS5Nc2dDcmVhdGVDbGllbnQ=",
+                "index": true
+              }
+            ]
+          },
+          {
+            "type": "create_client",
+            "attributes": [
+              {
+                "key": "Y2xpZW50X2lk",
+                "value": "MDYtc29sb21hY2hpbmUtMA==",
+                "index": true
+              },
+              {
+                "key": "Y2xpZW50X3R5cGU=",
+                "value": "MDYtc29sb21hY2hpbmU=",
+                "index": true
+              },
+              {
+                "key": "Y29uc2Vuc3VzX2hlaWdodA==",
+                "value": "MC0x",
+                "index": true
+              }
+            ]
+          },
+          {
+            "type": "message",
+            "attributes": [
+              {
+                "key": "bW9kdWxl",
+                "value": "aWJjX2NsaWVudA==",
+                "index": true
+              }
+            ]
+          }
+        ],
+        "codespace": ""
+      }
+    ],
+    "begin_block_events": [
+      {
+        "type": "coin_received",
+        "attributes": [
+          {
+            "key": "cmVjZWl2ZXI=",
+            "value": "dGNybzFtM2gzMHdsdnNmOGxscnV4dHB1a2R2c3kwa20ya3VtODdseDltcQ==",
+            "index": true
+          },
+          {
+            "key": "YW1vdW50",
+            "value": "NDc5Njk3NjQ0M2Jhc2V0Y3Jv",
+            "index": true
+          }
+        ]
+      },
+      {
+        "type": "coinbase",
+        "attributes": [
+          {
+            "key": "bWludGVy",
+            "value": "dGNybzFtM2gzMHdsdnNmOGxscnV4dHB1a2R2c3kwa20ya3VtODdseDltcQ==",
+            "index": true
+          },
+          {
+            "key": "YW1vdW50",
+            "value": "NDc5Njk3NjQ0M2Jhc2V0Y3Jv",
+            "index": true
+          }
+        ]
+      },
+      {
+        "type": "coin_spent",
+        "attributes": [
+          {
+            "key": "c3BlbmRlcg==",
+            "value": "dGNybzFtM2gzMHdsdnNmOGxscnV4dHB1a2R2c3kwa20ya3VtODdseDltcQ==",
+            "index": true
+          },
+          {
+            "key": "YW1vdW50",
+            "value": "NDc5Njk3NjQ0M2Jhc2V0Y3Jv",
+            "index": true
+          }
+        ]
+      },
+      {
+        "type": "coin_received",
+        "attributes": [
+          {
+            "key": "cmVjZWl2ZXI=",
+            "value": "dGNybzE3eHBmdmFrbTJhbWc5NjJ5bHM2Zjg0ejNrZWxsOGM1bHhoemFoYQ==",
+            "index": true
+          },
+          {
+            "key": "YW1vdW50",
+            "value": "NDc5Njk3NjQ0M2Jhc2V0Y3Jv",
+            "index": true
+          }
+        ]
+      },
+      {
+        "type": "transfer",
+        "attributes": [
+          {
+            "key": "cmVjaXBpZW50",
+            "value": "dGNybzE3eHBmdmFrbTJhbWc5NjJ5bHM2Zjg0ejNrZWxsOGM1bHhoemFoYQ==",
+            "index": true
+          },
+          {
+            "key": "c2VuZGVy",
+            "value": "dGNybzFtM2gzMHdsdnNmOGxscnV4dHB1a2R2c3kwa20ya3VtODdseDltcQ==",
+            "index": true
+          },
+          {
+            "key": "YW1vdW50",
+            "value": "NDc5Njk3NjQ0M2Jhc2V0Y3Jv",
+            "index": true
+          }
+        ]
+      },
+      {
+        "type": "message",
+        "attributes": [
+          {
+            "key": "c2VuZGVy",
+            "value": "dGNybzFtM2gzMHdsdnNmOGxscnV4dHB1a2R2c3kwa20ya3VtODdseDltcQ==",
+            "index": true
+          }
+        ]
+      },
+      {
+        "type": "mint",
+        "attributes": [
+          {
+            "key": "Ym9uZGVkX3JhdGlv",
+            "value": "MC4wMDA1OTUyNjEwMjkwMTA2MDM=",
+            "index": true
+          },
+          {
+            "key": "aW5mbGF0aW9u",
+            "value": "MC4wMTIwMTQwMzIxMDY2NTE3MjY=",
+            "index": true
+          },
+          {
+            "key": "YW5udWFsX3Byb3Zpc2lvbnM=",
+            "value": "MzAyNzYyMTI3NjE4OTI3NjUuMDY2ODg3NTA5NjMyNjI5ODQ4",
+            "index": true
+          },
+          {
+            "key": "YW1vdW50",
+            "value": "NDc5Njk3NjQ0Mw==",
+            "index": true
+          }
+        ]
+      },
+      {
+        "type": "coin_spent",
+        "attributes": [
+          {
+            "key": "c3BlbmRlcg==",
+            "value": "dGNybzE3eHBmdmFrbTJhbWc5NjJ5bHM2Zjg0ejNrZWxsOGM1bHhoemFoYQ==",
+            "index": true
+          },
+          {
+            "key": "YW1vdW50",
+            "value": "NDc5Njk3NjQ0M2Jhc2V0Y3Jv",
+            "index": true
+          }
+        ]
+      },
+      {
+        "type": "coin_received",
+        "attributes": [
+          {
+            "key": "cmVjZWl2ZXI=",
+            "value": "dGNybzFqdjY1czNncnFmNnY2amwzZHA0dDZjOXQ5cms5OWNkODMzOXA0bA==",
+            "index": true
+          },
+          {
+            "key": "YW1vdW50",
+            "value": "NDc5Njk3NjQ0M2Jhc2V0Y3Jv",
+            "index": true
+          }
+        ]
+      },
+      {
+        "type": "transfer",
+        "attributes": [
+          {
+            "key": "cmVjaXBpZW50",
+            "value": "dGNybzFqdjY1czNncnFmNnY2amwzZHA0dDZjOXQ5cms5OWNkODMzOXA0bA==",
+            "index": true
+          },
+          {
+            "key": "c2VuZGVy",
+            "value": "dGNybzE3eHBmdmFrbTJhbWc5NjJ5bHM2Zjg0ejNrZWxsOGM1bHhoemFoYQ==",
+            "index": true
+          },
+          {
+            "key": "YW1vdW50",
+            "value": "NDc5Njk3NjQ0M2Jhc2V0Y3Jv",
+            "index": true
+          }
+        ]
+      },
+      {
+        "type": "message",
+        "attributes": [
+          {
+            "key": "c2VuZGVy",
+            "value": "dGNybzE3eHBmdmFrbTJhbWc5NjJ5bHM2Zjg0ejNrZWxsOGM1bHhoemFoYQ==",
+            "index": true
+          }
+        ]
+      },
+      {
+        "type": "proposer_reward",
+        "attributes": [
+          {
+            "key": "YW1vdW50",
+            "value": "MjM5ODQ4ODIyLjE1MDAwMDAwMDAwMDAwMDAwMGJhc2V0Y3Jv",
+            "index": true
+          },
+          {
+            "key": "dmFsaWRhdG9y",
+            "value": "dGNyb2NuY2wxNjN0djU5eXpnZXFjYXA4bHJzYTJyNHprNTgwaDhkZHI1YTBzZGQ=",
+            "index": true
+          }
+        ]
+      },
+      {
+        "type": "commission",
+        "attributes": [
+          {
+            "key": "YW1vdW50",
+            "value": "MjM5ODQ4ODIuMjE1MDAwMDAwMDAwMDAwMDAwYmFzZXRjcm8=",
+            "index": true
+          },
+          {
+            "key": "dmFsaWRhdG9y",
+            "value": "dGNyb2NuY2wxNjN0djU5eXpnZXFjYXA4bHJzYTJyNHprNTgwaDhkZHI1YTBzZGQ=",
+            "index": true
+          }
+        ]
+      },
+      {
+        "type": "rewards",
+        "attributes": [
+          {
+            "key": "YW1vdW50",
+            "value": "MjM5ODQ4ODIyLjE1MDAwMDAwMDAwMDAwMDAwMGJhc2V0Y3Jv",
+            "index": true
+          },
+          {
+            "key": "dmFsaWRhdG9y",
+            "value": "dGNyb2NuY2wxNjN0djU5eXpnZXFjYXA4bHJzYTJyNHprNTgwaDhkZHI1YTBzZGQ=",
+            "index": true
+          }
+        ]
+      },
+      {
+        "type": "commission",
+        "attributes": [
+          {
+            "key": "YW1vdW50",
+            "value": "MTUxODk0MTI3Ljc1MzE0OTc4OTY3NDc1ODcyMmJhc2V0Y3Jv",
+            "index": true
+          },
+          {
+            "key": "dmFsaWRhdG9y",
+            "value": "dGNyb2NuY2wxNGZ6a3N6NWg3MmV0NHNzanRxcHdzbWh6NnlzazZyNG5hNXRyNjM=",
+            "index": true
+          }
+        ]
+      },
+      {
+        "type": "rewards",
+        "attributes": [
+          {
+            "key": "YW1vdW50",
+            "value": "MTUxODk0MTI3Ny41MzE0OTc4OTY3NDc1ODcyMThiYXNldGNybw==",
+            "index": true
+          },
+          {
+            "key": "dmFsaWRhdG9y",
+            "value": "dGNyb2NuY2wxNGZ6a3N6NWg3MmV0NHNzanRxcHdzbWh6NnlzazZyNG5hNXRyNjM=",
+            "index": true
+          }
+        ]
+      },
+      {
+        "type": "commission",
+        "attributes": [
+          {
+            "key": "YW1vdW50",
+            "value": "MTUxODk0MTI3Ljc1MzE0OTc4OTY3NDc1ODcyMmJhc2V0Y3Jv",
+            "index": true
+          },
+          {
+            "key": "dmFsaWRhdG9y",
+            "value": "dGNyb2NuY2wxczRnZ3EyenV6dndnNWs4dm54Mnhmd3RkbTRjejZ3dG51cWtsN2E=",
+            "index": true
+          }
+        ]
+      },
+      {
+        "type": "rewards",
+        "attributes": [
+          {
+            "key": "YW1vdW50",
+            "value": "MTUxODk0MTI3Ny41MzE0OTc4OTY3NDc1ODcyMThiYXNldGNybw==",
+            "index": true
+          },
+          {
+            "key": "dmFsaWRhdG9y",
+            "value": "dGNyb2NuY2wxczRnZ3EyenV6dndnNWs4dm54Mnhmd3RkbTRjejZ3dG51cWtsN2E=",
+            "index": true
+          }
+        ]
+      },
+      {
+        "type": "commission",
+        "attributes": [
+          {
+            "key": "YW1vdW50",
+            "value": "MTUxODk0MTI3Ljc1MzE0OTc4OTY3NDc1ODcyMmJhc2V0Y3Jv",
+            "index": true
+          },
+          {
+            "key": "dmFsaWRhdG9y",
+            "value": "dGNyb2NuY2wxNjN0djU5eXpnZXFjYXA4bHJzYTJyNHprNTgwaDhkZHI1YTBzZGQ=",
+            "index": true
+          }
+        ]
+      },
+      {
+        "type": "rewards",
+        "attributes": [
+          {
+            "key": "YW1vdW50",
+            "value": "MTUxODk0MTI3Ny41MzE0OTc4OTY3NDc1ODcyMThiYXNldGNybw==",
+            "index": true
+          },
+          {
+            "key": "dmFsaWRhdG9y",
+            "value": "dGNyb2NuY2wxNjN0djU5eXpnZXFjYXA4bHJzYTJyNHprNTgwaDhkZHI1YTBzZGQ=",
+            "index": true
+          }
+        ]
+      },
+      {
+        "type": "commission",
+        "attributes": [
+          {
+            "key": "YW1vdW50",
+            "value": "MzAzNzguODI1NTUwNjI5NjA4NTg1NTQ4YmFzZXRjcm8=",
+            "index": true
+          },
+          {
+            "key": "dmFsaWRhdG9y",
+            "value": "dGNyb2NuY2wxazRuejJ5YWxzdXp1enhleGN4dXVnaHAzM2NmcWxzN2Uwcmd5bTk=",
+            "index": true
+          }
+        ]
+      },
+      {
+        "type": "rewards",
+        "attributes": [
+          {
+            "key": "YW1vdW50",
+            "value": "MzAzNzg4LjI1NTUwNjI5NjA4NTg1NTQ4M2Jhc2V0Y3Jv",
+            "index": true
+          },
+          {
+            "key": "dmFsaWRhdG9y",
+            "value": "dGNyb2NuY2wxazRuejJ5YWxzdXp1enhleGN4dXVnaHAzM2NmcWxzN2Uwcmd5bTk=",
+            "index": true
+          }
+        ]
+      }
+    ],
+    "end_block_events": null,
+    "validator_updates": null,
+    "consensus_param_updates": {
+      "block": {
+        "max_bytes": "500000",
+        "max_gas": "81500000"
+      },
+      "evidence": {
+        "max_age_num_blocks": "403200",
+        "max_age_duration": "2419200000000000",
+        "max_bytes": "150000"
+      },
+      "validator": {
+        "pub_key_types": [
+          "ed25519"
+        ]
+      }
+    }
+  }
+}
+`

--- a/usecase/parser/test/tx_msg_ibc_create_tendermint_client.go
+++ b/usecase/parser/test/tx_msg_ibc_create_tendermint_client.go
@@ -1,6 +1,6 @@
 package usecase_parser_test
 
-const TX_MSG_CREATE_CLIENT_BLOCK_RESP = `{
+const TX_MSG_CREATE_TENDERMINT_CLIENT_BLOCK_RESP = `{
     "jsonrpc": "2.0",
     "id": -1,
     "result": {
@@ -67,7 +67,7 @@ const TX_MSG_CREATE_CLIENT_BLOCK_RESP = `{
     }
 }`
 
-const TX_MSG_CREATE_CLIENT_BLOCK_RESULTS_RESP = `
+const TX_MSG_CREATE_TENDERMINT_CLIENT_BLOCK_RESULTS_RESP = `
 {
     "jsonrpc": "2.0",
     "id": -1,

--- a/usecase/parser/test/tx_msg_ibc_tendermint_update_client.go
+++ b/usecase/parser/test/tx_msg_ibc_tendermint_update_client.go
@@ -1,6 +1,6 @@
 package usecase_parser_test
 
-const TX_MSG_UPDATE_CLIENT_BLOCK_RESP = `{
+const TX_MSG_UPDATE_TENDERMINT_CLIENT_BLOCK_RESP = `{
   "jsonrpc": "2.0",
   "id": -1,
   "result": {
@@ -67,7 +67,7 @@ const TX_MSG_UPDATE_CLIENT_BLOCK_RESP = `{
   }
 }`
 
-const TX_MSG_UPDATE_CLIENT_BLOCK_RESULTS_RESP = `{
+const TX_MSG_UPDATE_TENDERMINT_CLIENT_BLOCK_RESULTS_RESP = `{
   "jsonrpc": "2.0",
   "id": -1,
   "result": {


### PR DESCRIPTION
Solution: fixed #490 

**This one is depended on PR #511 (ibc channel debug projection), please review that one first** 🙏 

### Changes

- Introduced a new table, which contain two columns `denom` and `hash`
- Added a new API to fetch all denom-hash mappings. `/ibc/denom-hash-mappings`

### Example API Response

```
{
    "result": [
        {
            "denom": "transfer/channel-0/solotoken",
            "hash": "1A35E932DCE61466ED9F72D0B436628C388FB1BC60CB23A055039B7DE54883CC"
        },
        {
            "denom": "transfer/channel-1/USDC",
            "hash": "C59CA0D4F324B119C79782232700A6920B2EACA776558D7319CFC36DEE5672BF"
        },
        {
            "denom": "transfer/channel-2/USDC",
            "hash": "21E9F91EE9AC1D7E2C3D002F4AA73CAAB61801B055FB6721D36F16BB890BE0A2"
        },
        {
            "denom": "transfer/channel-1/TEST",
            "hash": "96D929A2DDBAB720DA3AB084914A64D40920DCF8CCD06B32966FBAF3AE75BD24"
        },
        {
            "denom": "transfer/channel-2/TEST",
            "hash": "D6F89C93C2DA3753E81650E96153A2C3E6BCC781E42638AE7BE2635476E2B6BB"
        },
        {
            "denom": "transfer/channel-2/OTTER",
            "hash": "C63FD640F6213F1D23C2D28E73A7289E9524F8B6156107E40186834E27B1D3CE"
        }
    ]
}
```