### PR TITLE
Problem: missing created_at_block_time and last_activity_block_time sorting params for ibc channel list API

### DIFF
--- a/infrastructure/httpapi/handlers/ibc_channel.go
+++ b/infrastructure/httpapi/handlers/ibc_channel.go
@@ -43,13 +43,13 @@ func (handler *IBCChannel) ListChannels(ctx *fasthttp.RequestCtx) {
 
 	queryArgs := ctx.QueryArgs()
 	if queryArgs.Has("order") {
-		if string(queryArgs.Peek("order")) == "created_at_block_time.desc" {
+		if string(queryArgs.Peek("order")) == "createdAtBlockTime.desc" {
 			listOrder.MaybeCreatedAtBlockTime = &view_order_desc
-		} else if string(queryArgs.Peek("order")) == "created_at_block_time.asc" {
+		} else if string(queryArgs.Peek("order")) == "createdAtBlockTime.asc" {
 			listOrder.MaybeCreatedAtBlockTime = &view_order_asc
-		} else if string(queryArgs.Peek("order")) == "last_activity_block_time.desc" {
+		} else if string(queryArgs.Peek("order")) == "lastActivityBlockTime.desc" {
 			listOrder.MaybeLastActivityBlockTime = &view_order_desc
-		} else if string(queryArgs.Peek("order")) == "last_activity_block_time.asc" {
+		} else if string(queryArgs.Peek("order")) == "lastActivityBlockTime.asc" {
 			listOrder.MaybeLastActivityBlockTime = &view_order_asc
 		}
 	}

--- a/infrastructure/httpapi/handlers/ibc_channel.go
+++ b/infrastructure/httpapi/handlers/ibc_channel.go
@@ -37,17 +37,24 @@ func (handler *IBCChannel) ListChannels(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	channelIdOrder := view.ORDER_ASC
+	var listOrder ibc_channel_view.IBCChannelsListOrder
+	view_order_desc := view.ORDER_DESC
+	view_order_asc := view.ORDER_ASC
+
 	queryArgs := ctx.QueryArgs()
 	if queryArgs.Has("order") {
-		if string(queryArgs.Peek("order")) == "channel_id.desc" {
-			channelIdOrder = view.ORDER_DESC
+		if string(queryArgs.Peek("order")) == "created_at_block_time.desc" {
+			listOrder.MaybeCreatedAtBlockTime = &view_order_desc
+		} else if string(queryArgs.Peek("order")) == "created_at_block_time.asc" {
+			listOrder.MaybeCreatedAtBlockTime = &view_order_asc
+		} else if string(queryArgs.Peek("order")) == "last_activity_block_time.desc" {
+			listOrder.MaybeLastActivityBlockTime = &view_order_desc
+		} else if string(queryArgs.Peek("order")) == "last_activity_block_time.asc" {
+			listOrder.MaybeLastActivityBlockTime = &view_order_asc
 		}
 	}
 
-	ibcChannels, paginationResult, err := handler.ibcChannelsView.List(ibc_channel_view.IBCChannelsListOrder{
-		ChannelID: channelIdOrder,
-	}, pagination)
+	ibcChannels, paginationResult, err := handler.ibcChannelsView.List(listOrder, pagination)
 	if err != nil {
 		handler.logger.Errorf("error listing IBCChannel channels: %v", err)
 		httpapi.InternalServerError(ctx)

--- a/infrastructure/httpapi/handlers/ibc_channel.go
+++ b/infrastructure/httpapi/handlers/ibc_channel.go
@@ -54,7 +54,19 @@ func (handler *IBCChannel) ListChannels(ctx *fasthttp.RequestCtx) {
 		}
 	}
 
-	ibcChannels, paginationResult, err := handler.ibcChannelsView.List(listOrder, pagination)
+	var listFilter ibc_channel_view.IBCChannelsListFilter
+	view_filter_status_true := true
+	view_filter_status_false := false
+
+	if queryArgs.Has("status") {
+		if string(queryArgs.Peek("status")) == "true" {
+			listFilter.MaybeStatus = &view_filter_status_true
+		} else if string(queryArgs.Peek("status")) == "false" {
+			listFilter.MaybeStatus = &view_filter_status_false
+		}
+	}
+
+	ibcChannels, paginationResult, err := handler.ibcChannelsView.List(listOrder, listFilter, pagination)
 	if err != nil {
 		handler.logger.Errorf("error listing IBCChannel channels: %v", err)
 		httpapi.InternalServerError(ctx)

--- a/infrastructure/httpapi/handlers/ibc_channel.go
+++ b/infrastructure/httpapi/handlers/ibc_channel.go
@@ -9,6 +9,7 @@ import (
 	"github.com/crypto-com/chain-indexing/appinterface/rdb"
 	"github.com/crypto-com/chain-indexing/infrastructure/httpapi"
 	applogger "github.com/crypto-com/chain-indexing/internal/logger"
+	"github.com/crypto-com/chain-indexing/internal/primptr"
 	ibc_channel_view "github.com/crypto-com/chain-indexing/projection/ibc_channel/view"
 )
 
@@ -37,32 +38,27 @@ func (handler *IBCChannel) ListChannels(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	var listOrder ibc_channel_view.IBCChannelsListOrder
-	view_order_desc := view.ORDER_DESC
-	view_order_asc := view.ORDER_ASC
-
 	queryArgs := ctx.QueryArgs()
+
+	var listOrder ibc_channel_view.IBCChannelsListOrder
 	if queryArgs.Has("order") {
 		if string(queryArgs.Peek("order")) == "createdAtBlockTime.desc" {
-			listOrder.MaybeCreatedAtBlockTime = &view_order_desc
+			listOrder.MaybeCreatedAtBlockTime = primptr.String(view.ORDER_DESC)
 		} else if string(queryArgs.Peek("order")) == "createdAtBlockTime.asc" {
-			listOrder.MaybeCreatedAtBlockTime = &view_order_asc
+			listOrder.MaybeCreatedAtBlockTime = primptr.String(view.ORDER_ASC)
 		} else if string(queryArgs.Peek("order")) == "lastActivityBlockTime.desc" {
-			listOrder.MaybeLastActivityBlockTime = &view_order_desc
+			listOrder.MaybeLastActivityBlockTime = primptr.String(view.ORDER_DESC)
 		} else if string(queryArgs.Peek("order")) == "lastActivityBlockTime.asc" {
-			listOrder.MaybeLastActivityBlockTime = &view_order_asc
+			listOrder.MaybeLastActivityBlockTime = primptr.String(view.ORDER_ASC)
 		}
 	}
 
 	var listFilter ibc_channel_view.IBCChannelsListFilter
-	view_filter_status_true := true
-	view_filter_status_false := false
-
 	if queryArgs.Has("status") {
 		if string(queryArgs.Peek("status")) == "true" {
-			listFilter.MaybeStatus = &view_filter_status_true
+			listFilter.MaybeStatus = primptr.Bool(true)
 		} else if string(queryArgs.Peek("status")) == "false" {
-			listFilter.MaybeStatus = &view_filter_status_false
+			listFilter.MaybeStatus = primptr.Bool(false)
 		}
 	}
 

--- a/projection/ibc_channel/view/ibc_channels.go
+++ b/projection/ibc_channel/view/ibc_channels.go
@@ -425,7 +425,6 @@ func (ibcChannelsView *IBCChannels) FindBy(channelID string) (*IBCChannelRow, er
 	return &channel, nil
 }
 
-// List only return `opened` IBC channel
 func (ibcChannelsView *IBCChannels) List(
 	order IBCChannelsListOrder,
 	filter IBCChannelsListFilter,

--- a/projection/ibc_channel/view/ibc_channels.go
+++ b/projection/ibc_channel/view/ibc_channels.go
@@ -462,7 +462,7 @@ func (ibcChannelsView *IBCChannels) List(
 	)
 
 	if filter.MaybeStatus != nil {
-		if *filter.MaybeStatus == true {
+		if *filter.MaybeStatus {
 			// Filtered channels in `opened` status
 			stmtBuilder = stmtBuilder.Where("status = ?", "true")
 		} else {


### PR DESCRIPTION
Solution: fixed #514 

Provide optional query params for `ibc/channels`.

```
# sort by fields
order= lastActivityBlockHeight.asc
order= lastActivityBlockHeight.desc ------> default sorting
order= createdAtBlockTime.asc
order= createdAtBlockTime.desc

# optional filter by status
status=true
status=false
# if `status` filter NOT provided, will return channel in both status
```