### PR TITLE
Problem: update ibc channel projection based on findings

### DIFF
--- a/projection/ibc_channel/ibc_channel.go
+++ b/projection/ibc_channel/ibc_channel.go
@@ -22,11 +22,11 @@ import (
 var _ entity_projection.Projection = &IBCChannel{}
 
 var (
-	NewIBCChannels = ibc_channel_view.NewIBCChannelsView
-	NewIBCClients = ibc_channel_view.NewIBCClientsView
-	NewIBCConnections = ibc_channel_view.NewIBCConnectionsView
-	NewIBCDenomHashMapping = ibc_channel_view.NewIBCDenomHashMappingView
-	NewIBCChannelTraces = ibc_channel_view.NewIBCChannelTraces
+	NewIBCChannels               = ibc_channel_view.NewIBCChannelsView
+	NewIBCClients                = ibc_channel_view.NewIBCClientsView
+	NewIBCConnections            = ibc_channel_view.NewIBCConnectionsView
+	NewIBCDenomHashMapping       = ibc_channel_view.NewIBCDenomHashMappingView
+	NewIBCChannelTraces          = ibc_channel_view.NewIBCChannelTraces
 	UpdateLastHandledEventHeight = (*IBCChannel).UpdateLastHandledEventHeight
 )
 
@@ -72,6 +72,8 @@ func (_ *IBCChannel) GetEventsToListen() []string {
 		event_usecase.MSG_IBC_TRANSFER_TRANSFER_CREATED,
 		event_usecase.MSG_IBC_RECV_PACKET_CREATED,
 		event_usecase.MSG_IBC_ACKNOWLEDGEMENT_CREATED,
+		event_usecase.MSG_IBC_TIMEOUT_CREATED,
+		event_usecase.MSG_IBC_TIMEOUT_ON_CLOSE_CREATED,
 	}
 }
 
@@ -308,12 +310,37 @@ func (projection *IBCChannel) HandleEvents(height int64, events []event_entity.E
 				return fmt.Errorf("error updating channel last_activity_time: %w", err)
 			}
 
+			amount := msgIBCTransferTransfer.Params.PacketData.Amount.Uint64()
+			denom := msgIBCTransferTransfer.Params.PacketData.Denom
+			destinationChannelID := msgIBCTransferTransfer.Params.DestinationChannel
+			destinationPortID := msgIBCTransferTransfer.Params.DestinationPort
+			sourceChannelID := msgIBCTransferTransfer.Params.SourceChannel
+			sourcePortID := msgIBCTransferTransfer.Params.SourcePort
+
+			if err := updateBondedTokensWhenMsgIBCTransfer(
+				ibcChannelsView,
+				channelID,
+				amount,
+				denom,
+				destinationChannelID,
+				destinationPortID,
+				sourceChannelID,
+				sourcePortID,
+			); err != nil {
+				return fmt.Errorf("error updateChannelBondedTokensWhenMsgIBCTransfer: %v", err)
+			}
+
 			if projection.config.EnableTxMsgTrace {
 
-				amount := msgIBCTransferTransfer.Params.Token.Amount
 				msg, err := msgIBCTransferTransfer.ToJSON()
 				if err != nil {
 					return fmt.Errorf("error msgIBCTransferTransfer.ToJSON(): %w", err)
+				}
+
+				// Here the bonded_tokens has already been updated by the above updateBondedTokensWhenXXXX()
+				updatedBondedTokensJSON, err := getBondedTokensInJSON(ibcChannelsView, channelID)
+				if err != nil {
+					return fmt.Errorf("error getBondedTokensInJSON: %v", err)
 				}
 
 				if err := ibcChannelTracesView.Insert(&ibc_channel_view.IBCChannelTraceRow{
@@ -321,13 +348,13 @@ func (projection *IBCChannel) HandleEvents(height int64, events []event_entity.E
 					BlockHeight:         height,
 					SourceChannel:       msgIBCTransferTransfer.Params.SourceChannel,
 					DestinationChannel:  msgIBCTransferTransfer.Params.DestinationChannel,
-					Denom:               msgIBCTransferTransfer.Params.Token.Denom,
-					Amount:              strconv.FormatUint(amount, 10),
+					Denom:               msgIBCTransferTransfer.Params.PacketData.Denom,
+					Amount:              msgIBCTransferTransfer.Params.PacketData.Amount.String(),
 					Success:             "",
 					Error:               "",
 					MessageType:         msgIBCTransferTransfer.MsgName,
 					Message:             msg,
-					UpdatedBondedTokens: "{}",
+					UpdatedBondedTokens: updatedBondedTokensJSON,
 				}); err != nil {
 					return fmt.Errorf("error adding tx trace when MsgIBCTransferTransfer: %w", err)
 				}
@@ -362,8 +389,10 @@ func (projection *IBCChannel) HandleEvents(height int64, events []event_entity.E
 				denom := msgIBCRecvPacket.Params.MaybeFungibleTokenPacketData.Denom
 				destinationChannelID := msgIBCRecvPacket.Params.Packet.DestinationChannel
 				destinationPortID := msgIBCRecvPacket.Params.Packet.DestinationPort
+				sourceChannelID := msgIBCRecvPacket.Params.Packet.SourceChannel
+				sourcePortID := msgIBCRecvPacket.Params.Packet.SourcePort
 
-				if err := projection.updateBondedTokensWhenMsgIBCRecvPacket(
+				if err := updateBondedTokensWhenMsgIBCRecvPacket(
 					ibcChannelsView,
 					ibcDenomHashMappingView,
 					channelID,
@@ -371,13 +400,15 @@ func (projection *IBCChannel) HandleEvents(height int64, events []event_entity.E
 					denom,
 					destinationChannelID,
 					destinationPortID,
+					sourceChannelID,
+					sourcePortID,
 				); err != nil {
 					return fmt.Errorf("error updateChannelBondedTokensWhenMsgIBCRecvPacket: %w", err)
 				}
 
 			}
 
-			if projection.config.EnableTxMsgTrace {
+			if projection.config.EnableTxMsgTrace && msgIBCRecvPacket.Params.MaybeFungibleTokenPacketData != nil {
 
 				msg, err := msgIBCRecvPacket.ToJSON()
 				if err != nil {
@@ -391,13 +422,9 @@ func (projection *IBCChannel) HandleEvents(height int64, events []event_entity.E
 				}
 
 				// Here the bonded_tokens has already been updated by the above updateBondedTokensWhenXXXX()
-				updatedBondedTokens, err := ibcChannelsView.FindBondedTokensBy(channelID)
+				updatedBondedTokensJSON, err := getBondedTokensInJSON(ibcChannelsView, channelID)
 				if err != nil {
-					return fmt.Errorf("error finding channel updated bonded_tokens: %w", err)
-				}
-				updatedBondedTokensJSON, err := jsoniter.MarshalToString(updatedBondedTokens)
-				if err != nil {
-					return fmt.Errorf("error marshal updatedBondedTokens to string: %w", err)
+					return fmt.Errorf("error getBondedTokensInJSON: %v", err)
 				}
 
 				if err := ibcChannelTracesView.Insert(&ibc_channel_view.IBCChannelTraceRow{
@@ -423,44 +450,49 @@ func (projection *IBCChannel) HandleEvents(height int64, events []event_entity.E
 			// Transfer started by source chain
 			channelID := msgIBCAcknowledgement.Params.Packet.SourceChannel
 
-			lastOutPacketSequence := msgIBCAcknowledgement.Params.PacketSequence
-			if err := ibcChannelsView.UpdateSequence(channelID, "last_out_packet_sequence", lastOutPacketSequence); err != nil {
-				return fmt.Errorf("error updating last_out_packet_sequence: %w", err)
-			}
-
 			if err := ibcChannelsView.UpdateLastActivityTimeAndHeight(channelID, blockTime, height); err != nil {
 				return fmt.Errorf("error updating channel last_activity_time: %w", err)
 			}
 
-			if msgIBCAcknowledgement.Params.MaybeFungibleTokenPacketData.Success {
+			if msgIBCAcknowledgement.Params.MaybeFungibleTokenPacketData != nil {
 
-				// TotalTransferOutSuccessRate
-				if err := ibcChannelsView.Increment(channelID, "total_transfer_out_success_count", 1); err != nil {
-					return fmt.Errorf("error increasing total_transfer_out_success_count: %w", err)
-				}
-				if err := ibcChannelsView.UpdateTotalTransferOutSuccessRate(channelID); err != nil {
-					return fmt.Errorf("error updating total_transfer_out_success_rate: %w", err)
-				}
+				if msgIBCAcknowledgement.Params.MaybeFungibleTokenPacketData.Success {
 
-				amount := msgIBCAcknowledgement.Params.MaybeFungibleTokenPacketData.Amount.Uint64()
-				denom := msgIBCAcknowledgement.Params.MaybeFungibleTokenPacketData.Denom
-				destinationChannelID := msgIBCAcknowledgement.Params.Packet.DestinationChannel
-				destinationPortID := msgIBCAcknowledgement.Params.Packet.DestinationPort
+					// TotalTransferOutSuccessRate
+					if err := ibcChannelsView.Increment(channelID, "total_transfer_out_success_count", 1); err != nil {
+						return fmt.Errorf("error increasing total_transfer_out_success_count: %w", err)
+					}
+					if err := ibcChannelsView.UpdateTotalTransferOutSuccessRate(channelID); err != nil {
+						return fmt.Errorf("error updating total_transfer_out_success_rate: %w", err)
+					}
 
-				if err := projection.updateBondedTokensWhenMsgIBCAcknowledgement(
-					ibcChannelsView,
-					channelID,
-					amount,
-					denom,
-					destinationChannelID,
-					destinationPortID,
-				); err != nil {
-					return fmt.Errorf("error updateChannelBondedTokensWhenMsgIBCAcknowledgement: %w", err)
+				} else {
+
+					amount := msgIBCAcknowledgement.Params.MaybeFungibleTokenPacketData.Amount.Uint64()
+					denom := msgIBCAcknowledgement.Params.MaybeFungibleTokenPacketData.Denom
+					destinationChannelID := msgIBCAcknowledgement.Params.Packet.DestinationChannel
+					destinationPortID := msgIBCAcknowledgement.Params.Packet.DestinationPort
+					sourceChannelID := msgIBCAcknowledgement.Params.Packet.SourceChannel
+					sourcePortID := msgIBCAcknowledgement.Params.Packet.SourcePort
+
+					if err := revertUpdateBondedTokensWhenMsgIBCTransfer(
+						ibcChannelsView,
+						channelID,
+						amount,
+						denom,
+						destinationChannelID,
+						destinationPortID,
+						sourceChannelID,
+						sourcePortID,
+					); err != nil {
+						return fmt.Errorf("error revertUpdateBondedTokensWhenMsgIBCTransfer: %v", err)
+					}
+
 				}
 
 			}
 
-			if projection.config.EnableTxMsgTrace {
+			if projection.config.EnableTxMsgTrace && msgIBCAcknowledgement.Params.MaybeFungibleTokenPacketData != nil {
 
 				msg, err := msgIBCAcknowledgement.ToJSON()
 				if err != nil {
@@ -474,13 +506,9 @@ func (projection *IBCChannel) HandleEvents(height int64, events []event_entity.E
 				}
 
 				// Here the bonded_tokens has already been updated by the above updateBondedTokensWhenXXXX()
-				updatedBondedTokens, err := ibcChannelsView.FindBondedTokensBy(channelID)
+				updatedBondedTokensJSON, err := getBondedTokensInJSON(ibcChannelsView, channelID)
 				if err != nil {
-					return fmt.Errorf("error finding channel updated bonded_tokens: %w", err)
-				}
-				updatedBondedTokensJSON, err := jsoniter.MarshalToString(updatedBondedTokens)
-				if err != nil {
-					return fmt.Errorf("error marshal updatedBondedTokens to string: %w", err)
+					return fmt.Errorf("error getBondedTokensInJSON: %v", err)
 				}
 
 				if err := ibcChannelTracesView.Insert(&ibc_channel_view.IBCChannelTraceRow{
@@ -497,6 +525,136 @@ func (projection *IBCChannel) HandleEvents(height int64, events []event_entity.E
 					UpdatedBondedTokens: updatedBondedTokensJSON,
 				}); err != nil {
 					return fmt.Errorf("error adding tx trace when MsgIBCAcknowledgement: %w", err)
+				}
+
+			}
+
+		} else if msgIBCTimeout, ok := event.(*event_usecase.MsgIBCTimeout); ok {
+
+			// Transfer started by source chain
+			channelID := msgIBCTimeout.Params.Packet.SourceChannel
+
+			if err := ibcChannelsView.UpdateLastActivityTimeAndHeight(channelID, blockTime, height); err != nil {
+				return fmt.Errorf("error updating channel last_activity_time: %w", err)
+			}
+
+			if msgIBCTimeout.Params.MaybeMsgTransfer != nil {
+
+				amount := msgIBCTimeout.Params.MaybeMsgTransfer.RefundAmount
+				denom := msgIBCTimeout.Params.MaybeMsgTransfer.RefundDenom
+				destinationChannelID := msgIBCTimeout.Params.Packet.DestinationChannel
+				destinationPortID := msgIBCTimeout.Params.Packet.DestinationPort
+				sourceChannelID := msgIBCTimeout.Params.Packet.SourceChannel
+				sourcePortID := msgIBCTimeout.Params.Packet.SourcePort
+
+				if err := revertUpdateBondedTokensWhenMsgIBCTransfer(
+					ibcChannelsView,
+					channelID,
+					amount,
+					denom,
+					destinationChannelID,
+					destinationPortID,
+					sourceChannelID,
+					sourcePortID,
+				); err != nil {
+					return fmt.Errorf("error revertUpdateBondedTokensWhenMsgIBCTransfer: %v", err)
+				}
+
+			}
+
+			if projection.config.EnableTxMsgTrace && msgIBCTimeout.Params.MaybeMsgTransfer != nil {
+
+				amount := msgIBCTimeout.Params.MaybeMsgTransfer.RefundAmount
+				msg, err := msgIBCTimeout.ToJSON()
+				if err != nil {
+					return fmt.Errorf("error msgIBCTimeout.ToJSON(): %w", err)
+				}
+
+				// Here the bonded_tokens has already been updated by the above updateBondedTokensWhenXXXX()
+				updatedBondedTokensJSON, err := getBondedTokensInJSON(ibcChannelsView, channelID)
+				if err != nil {
+					return fmt.Errorf("error getBondedTokensInJSON: %v", err)
+				}
+
+				if err := ibcChannelTracesView.Insert(&ibc_channel_view.IBCChannelTraceRow{
+					ChannelID:           channelID,
+					BlockHeight:         height,
+					SourceChannel:       msgIBCTimeout.Params.Packet.SourceChannel,
+					DestinationChannel:  msgIBCTimeout.Params.Packet.DestinationChannel,
+					Denom:               msgIBCTimeout.Params.MaybeMsgTransfer.RefundDenom,
+					Amount:              strconv.FormatUint(amount, 10),
+					Success:             "",
+					Error:               "",
+					MessageType:         msgIBCTimeout.MsgName,
+					Message:             msg,
+					UpdatedBondedTokens: updatedBondedTokensJSON,
+				}); err != nil {
+					return fmt.Errorf("error adding tx trace when MsgIBCTimeout: %w", err)
+				}
+
+			}
+
+		} else if msgIBCTimeoutOnClose, ok := event.(*event_usecase.MsgIBCTimeoutOnClose); ok {
+
+			// Transfer started by source chain
+			channelID := msgIBCTimeoutOnClose.Params.Packet.SourceChannel
+
+			if err := ibcChannelsView.UpdateLastActivityTimeAndHeight(channelID, blockTime, height); err != nil {
+				return fmt.Errorf("error updating channel last_activity_time: %w", err)
+			}
+
+			if msgIBCTimeoutOnClose.Params.MaybeMsgTransfer != nil {
+
+				amount := msgIBCTimeoutOnClose.Params.MaybeMsgTransfer.RefundAmount
+				denom := msgIBCTimeoutOnClose.Params.MaybeMsgTransfer.RefundDenom
+				destinationChannelID := msgIBCTimeoutOnClose.Params.Packet.DestinationChannel
+				destinationPortID := msgIBCTimeoutOnClose.Params.Packet.DestinationPort
+				sourceChannelID := msgIBCTimeoutOnClose.Params.Packet.SourceChannel
+				sourcePortID := msgIBCTimeoutOnClose.Params.Packet.SourcePort
+
+				if err := revertUpdateBondedTokensWhenMsgIBCTransfer(
+					ibcChannelsView,
+					channelID,
+					amount,
+					denom,
+					destinationChannelID,
+					destinationPortID,
+					sourceChannelID,
+					sourcePortID,
+				); err != nil {
+					return fmt.Errorf("error revertUpdateBondedTokensWhenMsgIBCTransfer: %v", err)
+				}
+
+			}
+
+			if projection.config.EnableTxMsgTrace && msgIBCTimeoutOnClose.Params.MaybeMsgTransfer != nil {
+
+				amount := msgIBCTimeoutOnClose.Params.MaybeMsgTransfer.RefundAmount
+				msg, err := msgIBCTimeoutOnClose.ToJSON()
+				if err != nil {
+					return fmt.Errorf("error msgIBCTimeoutOnClose.ToJSON(): %w", err)
+				}
+
+				// Here the bonded_tokens has already been updated by the above updateBondedTokensWhenXXXX()
+				updatedBondedTokensJSON, err := getBondedTokensInJSON(ibcChannelsView, channelID)
+				if err != nil {
+					return fmt.Errorf("error getBondedTokensInJSON: %v", err)
+				}
+
+				if err := ibcChannelTracesView.Insert(&ibc_channel_view.IBCChannelTraceRow{
+					ChannelID:           channelID,
+					BlockHeight:         height,
+					SourceChannel:       msgIBCTimeoutOnClose.Params.Packet.SourceChannel,
+					DestinationChannel:  msgIBCTimeoutOnClose.Params.Packet.DestinationChannel,
+					Denom:               msgIBCTimeoutOnClose.Params.MaybeMsgTransfer.RefundDenom,
+					Amount:              strconv.FormatUint(amount, 10),
+					Success:             "",
+					Error:               "",
+					MessageType:         msgIBCTimeoutOnClose.MsgName,
+					Message:             msg,
+					UpdatedBondedTokens: updatedBondedTokensJSON,
+				}); err != nil {
+					return fmt.Errorf("error adding tx trace when MsgIBCTimeoutOnClose: %w", err)
 				}
 
 			}
@@ -524,35 +682,39 @@ func (projection *IBCChannel) updateBondedTokensWhenMsgIBCRecvPacket(
 	denom string,
 	destinationChannelID string,
 	destinationPortID string,
+	sourceChannelID string,
+	sourcePortID string,
 ) error {
 
 	bondedTokens, err := ibcChannelsView.FindBondedTokensBy(channelID)
 	if err != nil {
-		return fmt.Errorf("error finding channel bonded_tokens: %w", err)
+		return fmt.Errorf("error finding channel bonded_tokens: %v", err)
 	}
 
 	amountInCoinInt := coin.NewIntFromUint64(amount)
 
-	if projection.tokenOriginFromThisChain(bondedTokens, denom) {
-		// This token is from this chain, now it is sent back.
+	if receiverChainIsTokenSource(denom, sourceChannelID, sourcePortID) {
+		// This chain is token source, it is unbonded now.
 		// Subtract it from the bondedTokens.OnCouterpartyChain
 		token := ibc_channel_view.NewBondedToken(denom, amountInCoinInt)
-		projection.subtractTokenOnCounterpartyChain(bondedTokens, token)
+		if subtractErr := subtractTokenOnCounterpartyChain(bondedTokens, token); subtractErr != nil {
+			return fmt.Errorf("error subtractTokenOnCounterpartyChain: %v", subtractErr)
+		}
 	} else {
-		// This token is NOT from this chain.
+		// Counterparty chain is token source, it is bonded to this chain now.
 		// Add it to bondedTokens.OnThisChain
 		newDenom := fmt.Sprintf("%s/%s/%s", destinationPortID, destinationChannelID, denom)
 		token := ibc_channel_view.NewBondedToken(newDenom, amountInCoinInt)
-		projection.addTokenOnThisChain(bondedTokens, token)
+		addTokenOnThisChain(bondedTokens, token)
 
 		// For keeping record of denom-hash, we only interested in tokens sending to our chain
-		if err = projection.insertDenomHashMappingIfNotExist(ibcDenomHashMappingView, newDenom); err != nil {
-			return fmt.Errorf("error insertDenomHashMappingIfNotExist: %w", err)
+		if insertErr := insertDenomHashMappingIfNotExist(ibcDenomHashMappingView, newDenom); insertErr != nil {
+			return fmt.Errorf("error insertDenomHashMappingIfNotExist: %v", insertErr)
 		}
 	}
 
 	if err := ibcChannelsView.UpdateBondedTokens(channelID, bondedTokens); err != nil {
-		return fmt.Errorf("error ibcChannelsView.UpdateBondedTokens: %w", err)
+		return fmt.Errorf("error ibcChannelsView.UpdateBondedTokens: %v", err)
 	}
 
 	return nil
@@ -565,78 +727,108 @@ func (projection *IBCChannel) updateBondedTokensWhenMsgIBCAcknowledgement(
 	denom string,
 	destinationChannelID string,
 	destinationPortID string,
+	sourceChannelID string,
+	sourcePortID string,
 ) error {
 
 	bondedTokens, err := ibcChannelsView.FindBondedTokensBy(channelID)
 	if err != nil {
-		return fmt.Errorf("error ibcChannelsView.FindBondedTokensBy: %w", err)
+		return fmt.Errorf("error ibcChannelsView.FindBondedTokensBy: %v", err)
 	}
 
 	amountInCoinInt := coin.NewIntFromUint64(amount)
 
-	if projection.tokenOriginFromCounterpartyChain(bondedTokens, denom) {
-		// This token is from the counterparty chain, now it is sent back to counterparty chain.
+	if receiverChainIsTokenSource(denom, sourceChannelID, sourcePortID) {
+		// Counterparty chain is token source, it is unbonded now.
 		// Subtract it from the bondedTokens.OnThisChain
 		token := ibc_channel_view.NewBondedToken(denom, amountInCoinInt)
-		projection.subtractTokenOnThisChain(bondedTokens, token)
+		if subtractErr := subtractTokenOnThisChain(bondedTokens, token); subtractErr != nil {
+			return fmt.Errorf("error subtractTokenOnThisChain: %v", subtractErr)
+		}
 	} else {
-		// This token is NOT from the counterparty chain.
+		// This chain is token source, it is bonded to counterparty chain now.
 		// Add it to bondedTokens.OnCounterpartyChain
 		newDenom := fmt.Sprintf("%s/%s/%s", destinationPortID, destinationChannelID, denom)
 		token := ibc_channel_view.NewBondedToken(newDenom, amountInCoinInt)
-		projection.addTokenOnCounterpartyChain(bondedTokens, token)
+		addTokenOnCounterpartyChain(bondedTokens, token)
 	}
 
 	if err := ibcChannelsView.UpdateBondedTokens(channelID, bondedTokens); err != nil {
-		return fmt.Errorf("error ibcChannelsView.UpdateBondedTokens: %w", err)
+		return fmt.Errorf("error ibcChannelsView.UpdateBondedTokens: %v", err)
 	}
 
 	return nil
 }
 
-func (projection *IBCChannel) tokenOriginFromCounterpartyChain(bondedTokens *ibc_channel_view.BondedTokens, denom string) bool {
-	for _, token := range bondedTokens.OnThisChain {
-		if token.Denom == denom {
-			return true
+func revertUpdateBondedTokensWhenMsgIBCTransfer(
+	ibcChannelsView *ibc_channel_view.IBCChannels,
+	channelID string,
+	amount uint64,
+	denom string,
+	destinationChannelID string,
+	destinationPortID string,
+	sourceChannelID string,
+	sourcePortID string,
+) error {
+
+	bondedTokens, err := ibcChannelsView.FindBondedTokensBy(channelID)
+	if err != nil {
+		return fmt.Errorf("error ibcChannelsView.FindBondedTokensBy: %v", err)
+	}
+
+	amountInCoinInt := coin.NewIntFromUint64(amount)
+
+	// Revert the operation in updateBondedTokensWhenMsgIBCTransfer()
+	if receiverChainIsTokenSource(denom, sourceChannelID, sourcePortID) {
+		token := ibc_channel_view.NewBondedToken(denom, amountInCoinInt)
+		addTokenOnThisChain(bondedTokens, token)
+	} else {
+		newDenom := fmt.Sprintf("%s/%s/%s", destinationPortID, destinationChannelID, denom)
+		token := ibc_channel_view.NewBondedToken(newDenom, amountInCoinInt)
+		if subtractErr := subtractTokenOnCounterpartyChain(bondedTokens, token); subtractErr != nil {
+			return fmt.Errorf("error subtractTokenOnCounterpartyChain: %v", subtractErr)
 		}
 	}
-	return false
-}
 
-func (projection *IBCChannel) tokenOriginFromThisChain(bondedTokens *ibc_channel_view.BondedTokens, denom string) bool {
-	for _, token := range bondedTokens.OnCounterpartyChain {
-		if token.Denom == denom {
-			return true
-		}
+	if err := ibcChannelsView.UpdateBondedTokens(channelID, bondedTokens); err != nil {
+		return fmt.Errorf("error ibcChannelsView.UpdateBondedTokens: %v", err)
 	}
-	return false
+
+	return nil
 }
 
-func (projection *IBCChannel) subtractTokenOnThisChain(
+func receiverChainIsTokenSource(denom, packetSourceChannelID, packetSourcePortID string) bool {
+	denomPrefix := fmt.Sprintf("%s/%s", packetSourcePortID, packetSourceChannelID)
+	return strings.HasPrefix(denom, denomPrefix)
+}
+
+func subtractTokenOnThisChain(
 	bondedTokens *ibc_channel_view.BondedTokens,
 	newToken *ibc_channel_view.BondedToken,
-) {
+) error {
 	for i, token := range bondedTokens.OnThisChain {
 		if token.Denom == newToken.Denom {
 			bondedTokens.OnThisChain[i].Amount = bondedTokens.OnThisChain[i].Amount.Sub(newToken.Amount)
-			return
+			return nil
 		}
 	}
+	return fmt.Errorf("denom %s is not found on bondedTokens.OnThisChain", newToken.Denom)
 }
 
-func (projection *IBCChannel) subtractTokenOnCounterpartyChain(
+func subtractTokenOnCounterpartyChain(
 	bondedTokens *ibc_channel_view.BondedTokens,
 	newToken *ibc_channel_view.BondedToken,
-) {
+) error {
 	for i, token := range bondedTokens.OnCounterpartyChain {
 		if token.Denom == newToken.Denom {
 			bondedTokens.OnCounterpartyChain[i].Amount = bondedTokens.OnCounterpartyChain[i].Amount.Sub(newToken.Amount)
-			return
+			return nil
 		}
 	}
+	return fmt.Errorf("denom %s is not found on bondedTokens.OnCounterpartyChain", newToken.Denom)
 }
 
-func (projection *IBCChannel) addTokenOnCounterpartyChain(
+func addTokenOnCounterpartyChain(
 	bondedTokens *ibc_channel_view.BondedTokens,
 	newToken *ibc_channel_view.BondedToken,
 ) {
@@ -651,7 +843,7 @@ func (projection *IBCChannel) addTokenOnCounterpartyChain(
 	bondedTokens.OnCounterpartyChain = append(bondedTokens.OnCounterpartyChain, *newToken)
 }
 
-func (projection *IBCChannel) addTokenOnThisChain(
+func addTokenOnThisChain(
 	bondedTokens *ibc_channel_view.BondedTokens,
 	newToken *ibc_channel_view.BondedToken,
 ) {
@@ -689,4 +881,17 @@ func (projection *IBCChannel) insertDenomHashMappingIfNotExist(
 
 	// The record exists, do nothing
 	return nil
+}
+
+func getBondedTokensInJSON(
+	ibcChannelsView *ibc_channel_view.IBCChannels,
+	channelID string,
+) (string, error) {
+
+	updatedBondedTokens, err := ibcChannelsView.FindBondedTokensBy(channelID)
+	if err != nil {
+		return "", fmt.Errorf("error finding channel bonded_tokens: %w", err)
+	}
+	return jsoniter.MarshalToString(updatedBondedTokens)
+
 }

--- a/usecase/model/ibc/msg_transfer.go
+++ b/usecase/model/ibc/msg_transfer.go
@@ -8,6 +8,9 @@ type MsgTransferParams struct {
 	DestinationChannel string `json:"destinationChannel"`
 	ChannelOrdering    string `json:"channelOrdering"`
 	ConnectionID       string `json:"connectionId"`
+	// `PacketData.Denom` is always in the format of <port>/<channel>/<basedenom> or <basedenom>
+	// While `RawMsgTransfer.Token.Denom` is possible in the format of ibc/sha256(xxx)
+	PacketData FungibleTokenPacketData `json:"packetData"`
 }
 
 type RawMsgTransfer struct {

--- a/usecase/parser/ibcmsg/ibcmsg.go
+++ b/usecase/parser/ibcmsg/ibcmsg.go
@@ -809,6 +809,12 @@ func ParseMsgTransfer(
 		panic("missing `send_packet` event in TxsResult log")
 	}
 
+	packetData := event.MustGetAttributeByKey("packet_data")
+	var fungiblePacketData ibc_model.FungibleTokenPacketData
+	if unmarshalErr := jsoniter.Unmarshal([]byte(packetData), &fungiblePacketData); unmarshalErr != nil {
+		panic("unable to parse `send_packet` event, key `packet_data`")
+	}
+
 	msgTransferParams := ibc_model.MsgTransferParams{
 		RawMsgTransfer: rawMsg,
 
@@ -817,6 +823,7 @@ func ParseMsgTransfer(
 		DestinationChannel: event.MustGetAttributeByKey("packet_dst_channel"),
 		ChannelOrdering:    event.MustGetAttributeByKey("packet_channel_ordering"),
 		ConnectionID:       event.MustGetAttributeByKey("packet_connection"),
+		PacketData:         fungiblePacketData,
 	}
 
 	return []command.Command{command_usecase.NewCreateMsgIBCTransferTransfer(

--- a/usecase/parser/msg_ibc_transfer_transfer_test.go
+++ b/usecase/parser/msg_ibc_transfer_transfer_test.go
@@ -47,7 +47,13 @@ var _ = Describe("ParseMsgCommands", func() {
     "destinationPort": "transfer",
     "destinationChannel": "channel-0",
     "channelOrdering": "ORDER_UNORDERED",
-    "connectionId": "connection-0"
+    "connectionId": "connection-0",
+		"packetData": {
+      "sender": "cro10snhlvkpuc4xhq82uyg5ex2eezmmf5ed5tmqsv",
+      "receiver": "cro1dulwqgcdpemn8c34sjd92fxepz5p0sqpeevw7f",
+      "denom": "basecro",
+      "amount": "1234"
+    }
   }
 }
 `

--- a/usecase/parser/msg_ibc_transfer_transfer_test.go
+++ b/usecase/parser/msg_ibc_transfer_transfer_test.go
@@ -48,7 +48,7 @@ var _ = Describe("ParseMsgCommands", func() {
     "destinationChannel": "channel-0",
     "channelOrdering": "ORDER_UNORDERED",
     "connectionId": "connection-0",
-		"packetData": {
+    "packetData": {
       "sender": "cro10snhlvkpuc4xhq82uyg5ex2eezmmf5ed5tmqsv",
       "receiver": "cro1dulwqgcdpemn8c34sjd92fxepz5p0sqpeevw7f",
       "denom": "basecro",


### PR DESCRIPTION
Solution: fixed #529 

## Changes

### Add `PacketData` field to `MsgTransferParams`
The previous `MsgTransferParams.Token.Denom` is possible in format of `ibc/sha256(xxx)`.

In order to get the human-readable denom string, I added logic to parse `packet_data` field from `send_packet` block event.

So now, `MsgTransferParams.PacketData.Denom` is always a human-readable denom string. For example: `basecro` or `transfer/channel-0/basecro`.

### Token source checking
Use `denom`, `packetSourcePort`, `packetSourceChannel` to check if receiver chain is the token source.

If denom starts with `packetSourcePort/packetSourceChannel`, then the receiver chain is the token source.

### Update logic on `IBCChannel.BondedTokens`
1. `MsgTransfer` will update `BondedTokens`
2. `MsgRecvPacket` will update `BondedTokens`
3. `MsgAcknowledgement` success, do nothing
4. `MsgAcknowledgement` failure (contains error), revert what is done in previous `MsgTransfer`.
5. `MsgTimeout` and `MsgTimeoutOnClose`, revert what is done in previous `MsgTransfer`.

## Verification of the new logic

I ran the chain-indexing locally against `croeseid-4` and sync all the block to around height `798793`.

Then verified the calculated `bonded_tokens` on the `cronos-testnet-3` (`channel-129`) that is the same as the number from `cronos-testnet-3` total supply grpc endpoint.

Command in use:
`grpcurl -d '' cronos-testnet-3.crypto.org:9090 cosmos.bank.v1beta1.Query/TotalSupply`