### PR TITLE
Problem: need to add more accounts to AccountMessage projection when handling IBC messages

### DIFF
--- a/projection/account_message/account_message.go
+++ b/projection/account_message/account_message.go
@@ -649,7 +649,8 @@ func (projection *AccountMessage) HandleEvents(height int64, events []event_enti
 				},
 			})
 		} else if typedEvent, ok := event.(*event_usecase.MsgIBCAcknowledgement); ok {
-			accountMessages = append(accountMessages, view.AccountMessageRecord{
+
+			record := view.AccountMessageRecord{
 				Row: view.AccountMessageRow{
 					BlockHeight:     height,
 					BlockHash:       "",
@@ -663,25 +664,38 @@ func (projection *AccountMessage) HandleEvents(height int64, events []event_enti
 				Accounts: []string{
 					typedEvent.Params.Signer,
 				},
-			})
-		} else if typedEvent, ok := event.(*event_usecase.MsgIBCRecvPacket); ok {
-			if typedEvent.Params.MaybeFungibleTokenPacketData != nil {
-				accountMessages = append(accountMessages, view.AccountMessageRecord{
-					Row: view.AccountMessageRow{
-						BlockHeight:     height,
-						BlockHash:       "",
-						BlockTime:       utctime.UTCTime{},
-						TransactionHash: typedEvent.TxHash(),
-						Success:         typedEvent.TxSuccess(),
-						MessageIndex:    typedEvent.MsgIndex,
-						MessageType:     typedEvent.MsgType(),
-						Data:            typedEvent,
-					},
-					Accounts: []string{
-						typedEvent.Params.MaybeFungibleTokenPacketData.Receiver,
-					},
-				})
 			}
+
+			if typedEvent.Params.MaybeFungibleTokenPacketData != nil {
+				record.Accounts = append(record.Accounts, typedEvent.Params.MaybeFungibleTokenPacketData.Sender)
+			}
+
+			accountMessages = append(accountMessages, record)
+
+		} else if typedEvent, ok := event.(*event_usecase.MsgIBCRecvPacket); ok {
+
+			record := view.AccountMessageRecord{
+				Row: view.AccountMessageRow{
+					BlockHeight:     height,
+					BlockHash:       "",
+					BlockTime:       utctime.UTCTime{},
+					TransactionHash: typedEvent.TxHash(),
+					Success:         typedEvent.TxSuccess(),
+					MessageIndex:    typedEvent.MsgIndex,
+					MessageType:     typedEvent.MsgType(),
+					Data:            typedEvent,
+				},
+				Accounts: []string{
+					typedEvent.Params.Signer,
+				},
+			}
+
+			if typedEvent.Params.MaybeFungibleTokenPacketData != nil {
+				record.Accounts = append(record.Accounts, typedEvent.Params.MaybeFungibleTokenPacketData.Receiver)
+			}
+
+			accountMessages = append(accountMessages, record)
+
 		} else if typedEvent, ok := event.(*event_usecase.MsgIBCTransferTransfer); ok {
 			accountMessages = append(accountMessages, view.AccountMessageRecord{
 				Row: view.AccountMessageRow{
@@ -699,7 +713,8 @@ func (projection *AccountMessage) HandleEvents(height int64, events []event_enti
 				},
 			})
 		} else if typedEvent, ok := event.(*event_usecase.MsgIBCTimeout); ok {
-			accountMessages = append(accountMessages, view.AccountMessageRecord{
+
+			record := view.AccountMessageRecord{
 				Row: view.AccountMessageRow{
 					BlockHeight:     height,
 					BlockHash:       "",
@@ -713,9 +728,17 @@ func (projection *AccountMessage) HandleEvents(height int64, events []event_enti
 				Accounts: []string{
 					typedEvent.Params.Signer,
 				},
-			})
+			}
+
+			if typedEvent.Params.MaybeMsgTransfer != nil {
+				record.Accounts = append(record.Accounts, typedEvent.Params.MaybeMsgTransfer.RefundReceiver)
+			}
+
+			accountMessages = append(accountMessages, record)
+
 		} else if typedEvent, ok := event.(*event_usecase.MsgIBCTimeoutOnClose); ok {
-			accountMessages = append(accountMessages, view.AccountMessageRecord{
+
+			record := view.AccountMessageRecord{
 				Row: view.AccountMessageRow{
 					BlockHeight:     height,
 					BlockHash:       "",
@@ -729,7 +752,14 @@ func (projection *AccountMessage) HandleEvents(height int64, events []event_enti
 				Accounts: []string{
 					typedEvent.Params.Signer,
 				},
-			})
+			}
+
+			if typedEvent.Params.MaybeMsgTransfer != nil {
+				record.Accounts = append(record.Accounts, typedEvent.Params.MaybeMsgTransfer.RefundReceiver)
+			}
+
+			accountMessages = append(accountMessages, record)
+
 		} else if typedEvent, ok := event.(*event_usecase.MsgIBCChannelCloseInit); ok {
 			accountMessages = append(accountMessages, view.AccountMessageRecord{
 				Row: view.AccountMessageRow{

--- a/projection/account_message/account_message_test.go
+++ b/projection/account_message/account_message_test.go
@@ -3736,6 +3736,15 @@ func TestAccountMessage_HandleEvents(t *testing.T) {
 						},
 					}),
 					Params: ibc_model.MsgAcknowledgementParams{
+						MaybeFungibleTokenPacketData: &ibc_model.MsgAcknowledgementFungibleTokenPacketData{
+							FungibleTokenPacketData: ibc_model.FungibleTokenPacketData{
+								Sender:   "Sender",
+								Receiver: "Receiver",
+								Denom:    "Denom",
+								Amount:   json.NewNumericStringFromUint64(100),
+							},
+							Success: true,
+						},
 						RawMsgAcknowledgement: ibc_model.RawMsgAcknowledgement{
 							Signer: "Signer",
 						},
@@ -3759,6 +3768,18 @@ func TestAccountMessage_HandleEvents(t *testing.T) {
 				mockAccountMessagesTotalView.On(
 					"Increment",
 					"Signer:MsgAcknowledgement",
+					int64(1),
+				).Return(nil)
+
+				mockAccountMessagesTotalView.On(
+					"Increment",
+					"Sender:-",
+					int64(1),
+				).Return(nil)
+
+				mockAccountMessagesTotalView.On(
+					"Increment",
+					"Sender:MsgAcknowledgement",
 					int64(1),
 				).Return(nil)
 
@@ -3793,13 +3814,22 @@ func TestAccountMessage_HandleEvents(t *testing.T) {
 								MsgIndex:  0,
 							},
 							Params: ibc_model.MsgAcknowledgementParams{
+								MaybeFungibleTokenPacketData: &ibc_model.MsgAcknowledgementFungibleTokenPacketData{
+									FungibleTokenPacketData: ibc_model.FungibleTokenPacketData{
+										Sender:   "Sender",
+										Receiver: "Receiver",
+										Denom:    "Denom",
+										Amount:   json.NewNumericStringFromUint64(100),
+									},
+									Success: true,
+								},
 								RawMsgAcknowledgement: ibc_model.RawMsgAcknowledgement{
 									Signer: "Signer",
 								},
 							},
 						},
 					},
-					[]string{"Signer"},
+					[]string{"Signer", "Sender"},
 				).Return(nil)
 
 				account_message.UpdateLastHandledEventHeight = func(_ *account_message.AccountMessage, _ *rdb.Handle, _ int64) error {
@@ -3851,6 +3881,9 @@ func TestAccountMessage_HandleEvents(t *testing.T) {
 							Success:                true,
 							MaybeDenominationTrace: nil,
 						},
+						RawMsgRecvPacket: ibc_model.RawMsgRecvPacket{
+							Signer: "Signer",
+						},
 					},
 				},
 			},
@@ -3861,6 +3894,18 @@ func TestAccountMessage_HandleEvents(t *testing.T) {
 				account_message.NewAccountMessagesTotal = func(_ *rdb.Handle) account_message_view.AccountMessagesTotal {
 					return mockAccountMessagesTotalView
 				}
+
+				mockAccountMessagesTotalView.On(
+					"Increment",
+					"Signer:-",
+					int64(1),
+				).Return(nil)
+
+				mockAccountMessagesTotalView.On(
+					"Increment",
+					"Signer:MsgRecvPacket",
+					int64(1),
+				).Return(nil)
 
 				mockAccountMessagesTotalView.On(
 					"Increment",
@@ -3915,10 +3960,13 @@ func TestAccountMessage_HandleEvents(t *testing.T) {
 									Success:                true,
 									MaybeDenominationTrace: nil,
 								},
+								RawMsgRecvPacket: ibc_model.RawMsgRecvPacket{
+									Signer: "Signer",
+								},
 							},
 						},
 					},
-					[]string{"Receiver"},
+					[]string{"Signer", "Receiver"},
 				).Return(nil)
 
 				account_message.UpdateLastHandledEventHeight = func(_ *account_message.AccountMessage, _ *rdb.Handle, _ int64) error {

--- a/projection/account_transaction/account_transaction.go
+++ b/projection/account_transaction/account_transaction.go
@@ -329,8 +329,16 @@ func (projection *AccountTransaction) HandleEvents(height int64, events []event_
 		} else if typedEvent, ok := event.(*event_usecase.MsgIBCAcknowledgement); ok {
 			transactionInfos[typedEvent.TxHash()].AddAccount(typedEvent.Params.Signer)
 
+			if typedEvent.Params.MaybeFungibleTokenPacketData != nil {
+				transactionInfos[typedEvent.TxHash()].AddAccount(typedEvent.Params.MaybeFungibleTokenPacketData.Sender)
+			}
+
 		} else if typedEvent, ok := event.(*event_usecase.MsgIBCRecvPacket); ok {
-			transactionInfos[typedEvent.TxHash()].AddAccount(typedEvent.Params.MaybeFungibleTokenPacketData.Receiver)
+			transactionInfos[typedEvent.TxHash()].AddAccount(typedEvent.Params.Signer)
+
+			if typedEvent.Params.MaybeFungibleTokenPacketData != nil {
+				transactionInfos[typedEvent.TxHash()].AddAccount(typedEvent.Params.MaybeFungibleTokenPacketData.Receiver)
+			}
 
 		} else if typedEvent, ok := event.(*event_usecase.MsgIBCTransferTransfer); ok {
 			transactionInfos[typedEvent.TxHash()].AddAccount(typedEvent.Params.Sender)
@@ -338,8 +346,16 @@ func (projection *AccountTransaction) HandleEvents(height int64, events []event_
 		} else if typedEvent, ok := event.(*event_usecase.MsgIBCTimeout); ok {
 			transactionInfos[typedEvent.TxHash()].AddAccount(typedEvent.Params.Signer)
 
+			if typedEvent.Params.MaybeMsgTransfer != nil {
+				transactionInfos[typedEvent.TxHash()].AddAccount(typedEvent.Params.MaybeMsgTransfer.RefundReceiver)
+			}
+
 		} else if typedEvent, ok := event.(*event_usecase.MsgIBCTimeoutOnClose); ok {
 			transactionInfos[typedEvent.TxHash()].AddAccount(typedEvent.Params.Signer)
+
+			if typedEvent.Params.MaybeMsgTransfer != nil {
+				transactionInfos[typedEvent.TxHash()].AddAccount(typedEvent.Params.MaybeMsgTransfer.RefundReceiver)
+			}
 
 		} else if typedEvent, ok := event.(*event_usecase.MsgIBCChannelCloseInit); ok {
 			transactionInfos[typedEvent.TxHash()].AddAccount(typedEvent.Params.Signer)


### PR DESCRIPTION
Solution: fixed #546 

Added missing accounts in `AccountMessage` and `AccountTransaction` when handling MsgRecvPacket, MsgAcknowledgement, MsgTimeout and MsgTimeoutOnClose.