### PR TITLE
Problem: Current logic of "failed IBC transfer" maybe inaccurate

### DIFF
--- a/projection/ibc_channel/ibc_channel.go
+++ b/projection/ibc_channel/ibc_channel.go
@@ -268,27 +268,27 @@ func (projection *IBCChannel) HandleEvents(height int64, events []event_entity.E
 			}
 
 			channel := &ibc_channel_view.IBCChannelRow{
-				ChannelID:                    msgIBCChannelOpenInit.Params.ChannelID,
-				PortID:                       msgIBCChannelOpenInit.Params.PortID,
-				ConnectionID:                 msgIBCChannelOpenInit.Params.ConnectionID,
-				CounterpartyChannelID:        msgIBCChannelOpenInit.Params.Channel.Counterparty.ChannelID,
-				CounterpartyPortID:           msgIBCChannelOpenInit.Params.Channel.Counterparty.PortID,
-				CounterpartyChainID:          counterpartyChainID,
-				Status:                       types.STATUS_NOT_ESTABLISHED,
-				PacketOrdering:               msgIBCChannelOpenInit.Params.Channel.Ordering,
-				LastInPacketSequence:         0,
-				LastOutPacketSequence:        0,
-				TotalTransferInCount:         0,
-				TotalTransferOutCount:        0,
-				TotalTransferOutSuccessCount: 0,
-				TotalTransferOutSuccessRate:  0,
-				CreatedAtBlockTime:           utctime.FromUnixNano(0),
-				CreatedAtBlockHeight:         0,
-				Verified:                     false,
-				Description:                  "",
-				LastActivityBlockTime:        utctime.FromUnixNano(0),
-				LastActivityBlockHeight:      0,
-				BondedTokens:                 *ibc_channel_view.NewEmptyBondedTokens(),
+				ChannelID:                 msgIBCChannelOpenInit.Params.ChannelID,
+				PortID:                    msgIBCChannelOpenInit.Params.PortID,
+				ConnectionID:              msgIBCChannelOpenInit.Params.ConnectionID,
+				CounterpartyChannelID:     msgIBCChannelOpenInit.Params.Channel.Counterparty.ChannelID,
+				CounterpartyPortID:        msgIBCChannelOpenInit.Params.Channel.Counterparty.PortID,
+				CounterpartyChainID:       counterpartyChainID,
+				Status:                    types.STATUS_NOT_ESTABLISHED,
+				PacketOrdering:            msgIBCChannelOpenInit.Params.Channel.Ordering,
+				LastInPacketSequence:      0,
+				LastOutPacketSequence:     0,
+				TotalRelayInCount:         0,
+				TotalRelayOutCount:        0,
+				TotalRelayOutSuccessCount: 0,
+				TotalRelayOutSuccessRate:  0,
+				CreatedAtBlockTime:        utctime.FromUnixNano(0),
+				CreatedAtBlockHeight:      0,
+				Verified:                  false,
+				Description:               "",
+				LastActivityBlockTime:     utctime.FromUnixNano(0),
+				LastActivityBlockHeight:   0,
+				BondedTokens:              *ibc_channel_view.NewEmptyBondedTokens(),
 			}
 			if err := ibcChannelsView.Insert(channel); err != nil {
 				return fmt.Errorf("error inserting channel: %w", err)
@@ -303,27 +303,27 @@ func (projection *IBCChannel) HandleEvents(height int64, events []event_entity.E
 			}
 
 			channel := &ibc_channel_view.IBCChannelRow{
-				ChannelID:                    msgIBCChannelOpenTry.Params.ChannelID,
-				PortID:                       msgIBCChannelOpenTry.Params.PortID,
-				ConnectionID:                 msgIBCChannelOpenTry.Params.ConnectionID,
-				CounterpartyChannelID:        msgIBCChannelOpenTry.Params.Channel.Counterparty.ChannelID,
-				CounterpartyPortID:           msgIBCChannelOpenTry.Params.Channel.Counterparty.PortID,
-				CounterpartyChainID:          counterpartyChainID,
-				Status:                       types.STATUS_NOT_ESTABLISHED,
-				PacketOrdering:               msgIBCChannelOpenTry.Params.Channel.Ordering,
-				LastInPacketSequence:         0,
-				LastOutPacketSequence:        0,
-				TotalTransferInCount:         0,
-				TotalTransferOutCount:        0,
-				TotalTransferOutSuccessCount: 0,
-				TotalTransferOutSuccessRate:  0,
-				CreatedAtBlockTime:           utctime.FromUnixNano(0),
-				CreatedAtBlockHeight:         0,
-				Verified:                     false,
-				Description:                  "",
-				LastActivityBlockTime:        utctime.FromUnixNano(0),
-				LastActivityBlockHeight:      0,
-				BondedTokens:                 *ibc_channel_view.NewEmptyBondedTokens(),
+				ChannelID:                 msgIBCChannelOpenTry.Params.ChannelID,
+				PortID:                    msgIBCChannelOpenTry.Params.PortID,
+				ConnectionID:              msgIBCChannelOpenTry.Params.ConnectionID,
+				CounterpartyChannelID:     msgIBCChannelOpenTry.Params.Channel.Counterparty.ChannelID,
+				CounterpartyPortID:        msgIBCChannelOpenTry.Params.Channel.Counterparty.PortID,
+				CounterpartyChainID:       counterpartyChainID,
+				Status:                    types.STATUS_NOT_ESTABLISHED,
+				PacketOrdering:            msgIBCChannelOpenTry.Params.Channel.Ordering,
+				LastInPacketSequence:      0,
+				LastOutPacketSequence:     0,
+				TotalRelayInCount:         0,
+				TotalRelayOutCount:        0,
+				TotalRelayOutSuccessCount: 0,
+				TotalRelayOutSuccessRate:  0,
+				CreatedAtBlockTime:        utctime.FromUnixNano(0),
+				CreatedAtBlockHeight:      0,
+				Verified:                  false,
+				Description:               "",
+				LastActivityBlockTime:     utctime.FromUnixNano(0),
+				LastActivityBlockHeight:   0,
+				BondedTokens:              *ibc_channel_view.NewEmptyBondedTokens(),
 			}
 			if err := ibcChannelsView.Insert(channel); err != nil {
 				return fmt.Errorf("error inserting channel: %w", err)
@@ -386,12 +386,12 @@ func (projection *IBCChannel) HandleEvents(height int64, events []event_entity.E
 			// Transfer started by source chain
 			channelID := msgIBCTransferTransfer.Params.SourceChannel
 
-			// TotalTransferOutSuccessRate
-			if err := ibcChannelsView.Increment(channelID, "total_transfer_out_count", 1); err != nil {
-				return fmt.Errorf("error increasing total_transfer_out_count: %w", err)
+			// TotalRelayOutSuccessRate
+			if err := ibcChannelsView.Increment(channelID, "total_relay_out_count", 1); err != nil {
+				return fmt.Errorf("error increasing total_relay_out_count: %w", err)
 			}
-			if err := ibcChannelsView.UpdateTotalTransferOutSuccessRate(channelID); err != nil {
-				return fmt.Errorf("error updating total_transfer_out_success_rate: %w", err)
+			if err := ibcChannelsView.UpdateTotalRelayOutSuccessRate(channelID); err != nil {
+				return fmt.Errorf("error updating total_relay_out_success_rate: %w", err)
 			}
 
 			lastOutPacketSequence := msgIBCTransferTransfer.Params.PacketSequence
@@ -459,8 +459,8 @@ func (projection *IBCChannel) HandleEvents(height int64, events []event_entity.E
 			// Transfer started by destination chain
 			channelID := msgIBCRecvPacket.Params.Packet.DestinationChannel
 
-			if err := ibcChannelsView.Increment(channelID, "total_transfer_in_count", 1); err != nil {
-				return fmt.Errorf("error increasing total_transfer_in_count: %w", err)
+			if err := ibcChannelsView.Increment(channelID, "total_relay_in_count", 1); err != nil {
+				return fmt.Errorf("error increasing total_relay_in_count: %w", err)
 			}
 
 			lastInPacketSequence := msgIBCRecvPacket.Params.PacketSequence
@@ -544,19 +544,17 @@ func (projection *IBCChannel) HandleEvents(height int64, events []event_entity.E
 				return fmt.Errorf("error updating channel last_activity_time: %w", err)
 			}
 
+			// TotalRelayOutSuccessRate
+			if err := ibcChannelsView.Increment(channelID, "total_relay_out_success_count", 1); err != nil {
+				return fmt.Errorf("error increasing total_relay_out_success_count: %w", err)
+			}
+			if err := ibcChannelsView.UpdateTotalRelayOutSuccessRate(channelID); err != nil {
+				return fmt.Errorf("error updating total_relay_out_success_rate: %w", err)
+			}
+
 			if msgIBCAcknowledgement.Params.MaybeFungibleTokenPacketData != nil {
 
-				if msgIBCAcknowledgement.Params.MaybeFungibleTokenPacketData.Success {
-
-					// TotalTransferOutSuccessRate
-					if err := ibcChannelsView.Increment(channelID, "total_transfer_out_success_count", 1); err != nil {
-						return fmt.Errorf("error increasing total_transfer_out_success_count: %w", err)
-					}
-					if err := ibcChannelsView.UpdateTotalTransferOutSuccessRate(channelID); err != nil {
-						return fmt.Errorf("error updating total_transfer_out_success_rate: %w", err)
-					}
-
-				} else {
+				if !msgIBCAcknowledgement.Params.MaybeFungibleTokenPacketData.Success {
 
 					amount := msgIBCAcknowledgement.Params.MaybeFungibleTokenPacketData.Amount.String()
 					denom := msgIBCAcknowledgement.Params.MaybeFungibleTokenPacketData.Denom
@@ -628,6 +626,14 @@ func (projection *IBCChannel) HandleEvents(height int64, events []event_entity.E
 				return fmt.Errorf("error updating channel last_activity_time: %w", err)
 			}
 
+			// TotalRelayOutSuccessRate
+			if err := ibcChannelsView.Increment(channelID, "total_relay_out_success_count", 1); err != nil {
+				return fmt.Errorf("error increasing total_relay_out_success_count: %w", err)
+			}
+			if err := ibcChannelsView.UpdateTotalRelayOutSuccessRate(channelID); err != nil {
+				return fmt.Errorf("error updating total_relay_out_success_rate: %w", err)
+			}
+
 			if msgIBCTimeout.Params.MaybeMsgTransfer != nil {
 
 				amount := msgIBCTimeout.Params.MaybeMsgTransfer.RefundAmount.String()
@@ -691,6 +697,14 @@ func (projection *IBCChannel) HandleEvents(height int64, events []event_entity.E
 
 			if err := ibcChannelsView.UpdateLastActivityTimeAndHeight(channelID, blockTime, height); err != nil {
 				return fmt.Errorf("error updating channel last_activity_time: %w", err)
+			}
+
+			// TotalRelayOutSuccessRate
+			if err := ibcChannelsView.Increment(channelID, "total_relay_out_success_count", 1); err != nil {
+				return fmt.Errorf("error increasing total_relay_out_success_count: %w", err)
+			}
+			if err := ibcChannelsView.UpdateTotalRelayOutSuccessRate(channelID); err != nil {
+				return fmt.Errorf("error updating total_relay_out_success_rate: %w", err)
 			}
 
 			if msgIBCTimeoutOnClose.Params.MaybeMsgTransfer != nil {

--- a/projection/ibc_channel/ibc_channel_test.go
+++ b/projection/ibc_channel/ibc_channel_test.go
@@ -411,26 +411,26 @@ func TestIBCChannel_HandleEvents(t *testing.T) {
 				mockIbcChannelsView.On(
 					"Insert",
 					&ibc_channel_view.IBCChannelRow{
-						ChannelID:                    "ChannelID",
-						PortID:                       "PortID",
-						ConnectionID:                 "ConnectionID",
-						CounterpartyChannelID:        "CounterpartyChannelID",
-						CounterpartyPortID:           "CounterpartyPortID",
-						CounterpartyChainID:          "CounterpartyChainID",
-						Status:                       "NOT_ESTABLISHED",
-						PacketOrdering:               "Ordering",
-						LastInPacketSequence:         0,
-						LastOutPacketSequence:        0,
-						TotalTransferInCount:         0,
-						TotalTransferOutCount:        0,
-						TotalTransferOutSuccessCount: 0,
-						TotalTransferOutSuccessRate:  0,
-						CreatedAtBlockTime:           utctime.UTCTime{},
-						CreatedAtBlockHeight:         0,
-						Verified:                     false,
-						Description:                  "",
-						LastActivityBlockTime:        utctime.UTCTime{},
-						LastActivityBlockHeight:      0,
+						ChannelID:                 "ChannelID",
+						PortID:                    "PortID",
+						ConnectionID:              "ConnectionID",
+						CounterpartyChannelID:     "CounterpartyChannelID",
+						CounterpartyPortID:        "CounterpartyPortID",
+						CounterpartyChainID:       "CounterpartyChainID",
+						Status:                    "NOT_ESTABLISHED",
+						PacketOrdering:            "Ordering",
+						LastInPacketSequence:      0,
+						LastOutPacketSequence:     0,
+						TotalRelayInCount:         0,
+						TotalRelayOutCount:        0,
+						TotalRelayOutSuccessCount: 0,
+						TotalRelayOutSuccessRate:  0,
+						CreatedAtBlockTime:        utctime.UTCTime{},
+						CreatedAtBlockHeight:      0,
+						Verified:                  false,
+						Description:               "",
+						LastActivityBlockTime:     utctime.UTCTime{},
+						LastActivityBlockHeight:   0,
 						BondedTokens: ibc_channel_view.BondedTokens{
 							OnThisChain:         []ibc_channel_view.BondedToken{},
 							OnCounterpartyChain: []ibc_channel_view.BondedToken{},
@@ -495,26 +495,26 @@ func TestIBCChannel_HandleEvents(t *testing.T) {
 				mockIbcChannelsView.On(
 					"Insert",
 					&ibc_channel_view.IBCChannelRow{
-						ChannelID:                    "ChannelID",
-						PortID:                       "PortID",
-						ConnectionID:                 "ConnectionID",
-						CounterpartyChannelID:        "CounterpartyChannelID",
-						CounterpartyPortID:           "CounterpartyPortID",
-						CounterpartyChainID:          "CounterpartyChainID",
-						Status:                       "NOT_ESTABLISHED",
-						PacketOrdering:               "Ordering",
-						LastInPacketSequence:         0,
-						LastOutPacketSequence:        0,
-						TotalTransferInCount:         0,
-						TotalTransferOutCount:        0,
-						TotalTransferOutSuccessCount: 0,
-						TotalTransferOutSuccessRate:  0,
-						CreatedAtBlockTime:           utctime.UTCTime{},
-						CreatedAtBlockHeight:         0,
-						Verified:                     false,
-						Description:                  "",
-						LastActivityBlockTime:        utctime.UTCTime{},
-						LastActivityBlockHeight:      0,
+						ChannelID:                 "ChannelID",
+						PortID:                    "PortID",
+						ConnectionID:              "ConnectionID",
+						CounterpartyChannelID:     "CounterpartyChannelID",
+						CounterpartyPortID:        "CounterpartyPortID",
+						CounterpartyChainID:       "CounterpartyChainID",
+						Status:                    "NOT_ESTABLISHED",
+						PacketOrdering:            "Ordering",
+						LastInPacketSequence:      0,
+						LastOutPacketSequence:     0,
+						TotalRelayInCount:         0,
+						TotalRelayOutCount:        0,
+						TotalRelayOutSuccessCount: 0,
+						TotalRelayOutSuccessRate:  0,
+						CreatedAtBlockTime:        utctime.UTCTime{},
+						CreatedAtBlockHeight:      0,
+						Verified:                  false,
+						Description:               "",
+						LastActivityBlockTime:     utctime.UTCTime{},
+						LastActivityBlockHeight:   0,
 						BondedTokens: ibc_channel_view.BondedTokens{
 							OnThisChain:         []ibc_channel_view.BondedToken{},
 							OnCounterpartyChain: []ibc_channel_view.BondedToken{},
@@ -575,26 +575,26 @@ func TestIBCChannel_HandleEvents(t *testing.T) {
 				mockIbcChannelsView.On(
 					"UpdateFactualColumns",
 					&ibc_channel_view.IBCChannelRow{
-						ChannelID:                    "ChannelID",
-						PortID:                       "PortID",
-						ConnectionID:                 "ConnectionID",
-						CounterpartyChannelID:        "CounterpartyChannelID",
-						CounterpartyPortID:           "CounterpartyPortID",
-						CounterpartyChainID:          "CounterpartyChainID",
-						Status:                       "",
-						PacketOrdering:               "",
-						LastInPacketSequence:         0,
-						LastOutPacketSequence:        0,
-						TotalTransferInCount:         0,
-						TotalTransferOutCount:        0,
-						TotalTransferOutSuccessCount: 0,
-						TotalTransferOutSuccessRate:  0,
-						CreatedAtBlockTime:           utctime.UTCTime{},
-						CreatedAtBlockHeight:         1,
-						Verified:                     false,
-						Description:                  "",
-						LastActivityBlockTime:        utctime.UTCTime{},
-						LastActivityBlockHeight:      0,
+						ChannelID:                 "ChannelID",
+						PortID:                    "PortID",
+						ConnectionID:              "ConnectionID",
+						CounterpartyChannelID:     "CounterpartyChannelID",
+						CounterpartyPortID:        "CounterpartyPortID",
+						CounterpartyChainID:       "CounterpartyChainID",
+						Status:                    "",
+						PacketOrdering:            "",
+						LastInPacketSequence:      0,
+						LastOutPacketSequence:     0,
+						TotalRelayInCount:         0,
+						TotalRelayOutCount:        0,
+						TotalRelayOutSuccessCount: 0,
+						TotalRelayOutSuccessRate:  0,
+						CreatedAtBlockTime:        utctime.UTCTime{},
+						CreatedAtBlockHeight:      1,
+						Verified:                  false,
+						Description:               "",
+						LastActivityBlockTime:     utctime.UTCTime{},
+						LastActivityBlockHeight:   0,
 						BondedTokens: ibc_channel_view.BondedTokens{
 							OnThisChain:         []ibc_channel_view.BondedToken(nil),
 							OnCounterpartyChain: []ibc_channel_view.BondedToken(nil),
@@ -660,26 +660,26 @@ func TestIBCChannel_HandleEvents(t *testing.T) {
 				mockIbcChannelsView.On(
 					"UpdateFactualColumns",
 					&ibc_channel_view.IBCChannelRow{
-						ChannelID:                    "ChannelID",
-						PortID:                       "PortID",
-						ConnectionID:                 "ConnectionID",
-						CounterpartyChannelID:        "CounterpartyChannelID",
-						CounterpartyPortID:           "CounterpartyPortID",
-						CounterpartyChainID:          "CounterpartyChainID",
-						Status:                       "",
-						PacketOrdering:               "",
-						LastInPacketSequence:         0,
-						LastOutPacketSequence:        0,
-						TotalTransferInCount:         0,
-						TotalTransferOutCount:        0,
-						TotalTransferOutSuccessCount: 0,
-						TotalTransferOutSuccessRate:  0,
-						CreatedAtBlockTime:           utctime.UTCTime{},
-						CreatedAtBlockHeight:         1,
-						Verified:                     false,
-						Description:                  "",
-						LastActivityBlockTime:        utctime.UTCTime{},
-						LastActivityBlockHeight:      0,
+						ChannelID:                 "ChannelID",
+						PortID:                    "PortID",
+						ConnectionID:              "ConnectionID",
+						CounterpartyChannelID:     "CounterpartyChannelID",
+						CounterpartyPortID:        "CounterpartyPortID",
+						CounterpartyChainID:       "CounterpartyChainID",
+						Status:                    "",
+						PacketOrdering:            "",
+						LastInPacketSequence:      0,
+						LastOutPacketSequence:     0,
+						TotalRelayInCount:         0,
+						TotalRelayOutCount:        0,
+						TotalRelayOutSuccessCount: 0,
+						TotalRelayOutSuccessRate:  0,
+						CreatedAtBlockTime:        utctime.UTCTime{},
+						CreatedAtBlockHeight:      1,
+						Verified:                  false,
+						Description:               "",
+						LastActivityBlockTime:     utctime.UTCTime{},
+						LastActivityBlockHeight:   0,
 						BondedTokens: ibc_channel_view.BondedTokens{
 							OnThisChain:         []ibc_channel_view.BondedToken(nil),
 							OnCounterpartyChain: []ibc_channel_view.BondedToken(nil),
@@ -740,12 +740,12 @@ func TestIBCChannel_HandleEvents(t *testing.T) {
 				mockIbcChannelsView.On(
 					"Increment",
 					"SourceChannel",
-					"total_transfer_out_count",
+					"total_relay_out_count",
 					int64(1),
 				).Return(nil)
 
 				mockIbcChannelsView.On(
-					"UpdateTotalTransferOutSuccessRate",
+					"UpdateTotalRelayOutSuccessRate",
 					"SourceChannel",
 				).Return(nil)
 
@@ -862,7 +862,7 @@ func TestIBCChannel_HandleEvents(t *testing.T) {
 				mockIbcChannelsView.On(
 					"Increment",
 					"DestinationChannel",
-					"total_transfer_in_count",
+					"total_relay_in_count",
 					int64(1),
 				).Return(nil)
 
@@ -996,7 +996,7 @@ func TestIBCChannel_HandleEvents(t *testing.T) {
 				mockIbcChannelsView.On(
 					"Increment",
 					"DestinationChannel",
-					"total_transfer_in_count",
+					"total_relay_in_count",
 					int64(1),
 				).Return(nil)
 
@@ -1072,12 +1072,12 @@ func TestIBCChannel_HandleEvents(t *testing.T) {
 				mockIbcChannelsView.On(
 					"Increment",
 					"SourceChannel",
-					"total_transfer_out_success_count",
+					"total_relay_out_success_count",
 					int64(1),
 				).Return(nil)
 
 				mockIbcChannelsView.On(
-					"UpdateTotalTransferOutSuccessRate",
+					"UpdateTotalRelayOutSuccessRate",
 					"SourceChannel",
 				).Return(nil)
 
@@ -1136,6 +1136,18 @@ func TestIBCChannel_HandleEvents(t *testing.T) {
 					"SourceChannel",
 					utctime.UTCTime{},
 					int64(1),
+				).Return(nil)
+
+				mockIbcChannelsView.On(
+					"Increment",
+					"SourceChannel",
+					"total_relay_out_success_count",
+					int64(1),
+				).Return(nil)
+
+				mockIbcChannelsView.On(
+					"UpdateTotalRelayOutSuccessRate",
+					"SourceChannel",
 				).Return(nil)
 
 				mockIbcChannelsView.On(
@@ -1236,6 +1248,18 @@ func TestIBCChannel_HandleEvents(t *testing.T) {
 				).Return(nil)
 
 				mockIbcChannelsView.On(
+					"Increment",
+					"SourceChannel",
+					"total_relay_out_success_count",
+					int64(1),
+				).Return(nil)
+
+				mockIbcChannelsView.On(
+					"UpdateTotalRelayOutSuccessRate",
+					"SourceChannel",
+				).Return(nil)
+
+				mockIbcChannelsView.On(
 					"FindBondedTokensBy",
 					"SourceChannel",
 				).Return(
@@ -1330,6 +1354,18 @@ func TestIBCChannel_HandleEvents(t *testing.T) {
 					"SourceChannel",
 					utctime.UTCTime{},
 					int64(1),
+				).Return(nil)
+
+				mockIbcChannelsView.On(
+					"Increment",
+					"SourceChannel",
+					"total_relay_out_success_count",
+					int64(1),
+				).Return(nil)
+
+				mockIbcChannelsView.On(
+					"UpdateTotalRelayOutSuccessRate",
+					"SourceChannel",
 				).Return(nil)
 
 				mockIbcChannelsView.On(

--- a/projection/ibc_channel/migrations/20211109173428_alter_view_ibc_channels_columns.down.sql
+++ b/projection/ibc_channel/migrations/20211109173428_alter_view_ibc_channels_columns.down.sql
@@ -1,0 +1,12 @@
+
+ALTER TABLE view_ibc_channels 
+RENAME COLUMN total_relay_in_count TO total_transfer_in_count;
+
+ALTER TABLE view_ibc_channels 
+RENAME COLUMN total_relay_out_count TO total_transfer_out_count;
+
+ALTER TABLE view_ibc_channels 
+RENAME COLUMN total_relay_out_success_count TO total_transfer_out_success_count;
+
+ALTER TABLE view_ibc_channels 
+RENAME COLUMN total_relay_out_success_rate TO total_transfer_out_success_rate;

--- a/projection/ibc_channel/migrations/20211109173428_alter_view_ibc_channels_columns.up.sql
+++ b/projection/ibc_channel/migrations/20211109173428_alter_view_ibc_channels_columns.up.sql
@@ -1,0 +1,11 @@
+ALTER TABLE view_ibc_channels 
+RENAME COLUMN total_transfer_in_count TO total_relay_in_count;
+
+ALTER TABLE view_ibc_channels 
+RENAME COLUMN total_transfer_out_count TO total_relay_out_count;
+
+ALTER TABLE view_ibc_channels 
+RENAME COLUMN total_transfer_out_success_count TO total_relay_out_success_count;
+
+ALTER TABLE view_ibc_channels 
+RENAME COLUMN total_transfer_out_success_rate TO total_relay_out_success_rate;

--- a/projection/ibc_channel/view/ibc_channels_mock.go
+++ b/projection/ibc_channel/view/ibc_channels_mock.go
@@ -36,7 +36,7 @@ func (ibcChannelsView *MockIBCChannelsView) UpdateSequence(channelID string, col
 	return mockArgs.Error(0)
 }
 
-func (ibcChannelsView *MockIBCChannelsView) UpdateTotalTransferOutSuccessRate(channelID string) error {
+func (ibcChannelsView *MockIBCChannelsView) UpdateTotalRelayOutSuccessRate(channelID string) error {
 	mockArgs := ibcChannelsView.Called(channelID)
 	return mockArgs.Error(0)
 }


### PR DESCRIPTION
Solution: fixed #590 

## Changes:
- Renamed ibc_channel table columns `total_transfer_*` to `total_relay_*`.
- Success rate now indicates the ratio of successfully relayed `IBC Transfer`
- Updated related test cases

## A small reminder:
If you want to test newly added migration script, you will need to update `MIGRATION_GITHUB_TARGET`.

First, you need to pushed your code to a branch, then change the const:
`MIGRATION_GITHUB_TARGET = "github://%s:%s@crypto-com/chain-indexing/%s#<YOUR_BRANCH_NAME>"`

For example, to test this branch locally, you will need to change it to:
`MIGRATION_GITHUB_TARGET = "github://%s:%s@crypto-com/chain-indexing/%s#fix/590-relay-out-success-rate"`