### PR TITLE
Problem: IBC Transfer Message denom not in fixed format

### DIFF
--- a/projection/ibc_channel_message/ibc_channel_message.go
+++ b/projection/ibc_channel_message/ibc_channel_message.go
@@ -174,8 +174,8 @@ func (projection *IBCChannelMessage) HandleEvents(height int64, events []event_e
 				TransactionHash: typedEvent.TxHash(),
 				MaybeSender:     primptr.String(typedEvent.Params.Sender),
 				MaybeReceiver:   primptr.String(typedEvent.Params.Receiver),
-				MaybeDenom:      primptr.String(typedEvent.Params.Token.Denom),
-				MaybeAmount:     primptr.String(typedEvent.Params.Token.Amount.String()),
+				MaybeDenom:      primptr.String(typedEvent.Params.PacketData.Denom),
+				MaybeAmount:     primptr.String(typedEvent.Params.PacketData.Amount.String()),
 				MessageType:     typedEvent.MsgName,
 				Message:         typedEvent,
 			}

--- a/projection/ibc_channel_message/ibc_channel_message_test.go
+++ b/projection/ibc_channel_message/ibc_channel_message_test.go
@@ -335,6 +335,12 @@ func TestIBCChannelMessage_HandleEvents(t *testing.T) {
 								Amount: json.NewNumericStringFromUint64(1000),
 							},
 						},
+						PacketData: ibc_model.FungibleTokenPacketData{
+							Sender:   "PacketDataSender",
+							Receiver: "PacketDataReceiver",
+							Denom:    "PacketDataDenom",
+							Amount:   json.NewNumericStringFromUint64(10000),
+						},
 					},
 				},
 			},
@@ -351,8 +357,8 @@ func TestIBCChannelMessage_HandleEvents(t *testing.T) {
 						TransactionHash: "TxHash",
 						MaybeSender:     primptr.String("Sender"),
 						MaybeReceiver:   primptr.String("Receiver"),
-						MaybeDenom:      primptr.String("Denom"),
-						MaybeAmount:     primptr.String("1000"),
+						MaybeDenom:      primptr.String("PacketDataDenom"),
+						MaybeAmount:     primptr.String("10000"),
 						MessageType:     "MsgTransfer",
 						Message:         typedEvent,
 					}).


### PR DESCRIPTION
Solution: fix #646 

Details are in the issue description.