### PR TITLE
Problem: MsgExec may squeeze multiple message events into a single one

### DIFF
--- a/usecase/parser/inner_msg.go
+++ b/usecase/parser/inner_msg.go
@@ -1,0 +1,145 @@
+package parser
+
+import (
+	"github.com/crypto-com/chain-indexing/usecase/model"
+	"github.com/crypto-com/chain-indexing/usecase/parser/utils"
+)
+
+func ParseTxsResultsEvents(
+	innerMsgType string,
+	logs model.BlockResultsTxsResultLog,
+	innerMsgIndex int,
+) []model.BlockResultsTxsResultLog {
+	var resultLog []model.BlockResultsTxsResultLog
+
+	parsedEvents := utils.NewParsedTxsResultsEvents(logs.Events)
+	validateEvents := ParseInnerMsgsEvents(innerMsgType, innerMsgIndex, parsedEvents)
+
+	log := model.BlockResultsTxsResultLog{
+		MsgIndex: innerMsgIndex,
+		Events:   validateEvents,
+	}
+	resultLog = append(resultLog, log)
+
+	return resultLog
+}
+
+func ParseInnerMsgsEvents(
+	innerMsgType string,
+	innerMsgIndex int,
+	parsedEvents *utils.ParsedTxsResultsEvents,
+) []model.BlockResultsEvent {
+	var extractedEvents []model.BlockResultsEvent
+	switch innerMsgType {
+
+	// bank
+	case "/cosmos.bank.v1beta1.MsgSend":
+		extractedEvents = MsgSend(parsedEvents, innerMsgIndex)
+
+	// distribution
+	case "/cosmos.distribution.v1beta1.MsgSetWithdrawAddress":
+		extractedEvents = MsgSetWithdrawAddress(parsedEvents, innerMsgIndex)
+	case "/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward":
+		extractedEvents = MsgWithdrawDelegatorReward(parsedEvents, innerMsgIndex)
+	case "/cosmos.distribution.v1beta1.MsgWithdrawValidatorCommission":
+		extractedEvents = MsgWithdrawValidatorCommission(parsedEvents, innerMsgIndex)
+	case "/cosmos.distribution.v1beta1.MsgFundCommunityPool":
+		extractedEvents = MsgFundCommunityPool(parsedEvents, innerMsgIndex)
+	}
+
+	return extractedEvents
+}
+
+func MsgSend(parsedEvents *utils.ParsedTxsResultsEvents,
+	innerMsgIndex int,
+) []model.BlockResultsEvent {
+	eventTypes := []string{"coin_spent", "coin_received", "transfer", "message"}
+
+	return extract(innerMsgIndex, eventTypes, []string{}, parsedEvents)
+}
+
+func MsgSetWithdrawAddress(parsedEvents *utils.ParsedTxsResultsEvents,
+	innerMsgIndex int,
+) []model.BlockResultsEvent {
+	eventTypes := []string{"set_withdraw_address", "message"}
+
+	return extract(innerMsgIndex, eventTypes, []string{}, parsedEvents)
+}
+
+func MsgWithdrawDelegatorReward(parsedEvents *utils.ParsedTxsResultsEvents,
+	innerMsgIndex int,
+) []model.BlockResultsEvent {
+	eventTypes := []string{"coin_spent", "coin_received", "transfer", "message", "withdraw_rewards"}
+
+	eventTypesNoTransfer := []string{
+		"message",
+		"withdraw_rewards",
+	}
+	return extract(innerMsgIndex, eventTypes, eventTypesNoTransfer, parsedEvents)
+}
+
+func MsgWithdrawValidatorCommission(parsedEvents *utils.ParsedTxsResultsEvents,
+	innerMsgIndex int,
+) []model.BlockResultsEvent {
+	eventTypes := []string{"coin_spent", "coin_received", "transfer", "message", "withdraw_commission"}
+
+	eventTypesNoTransfer := []string{"message", "withdraw_commission"}
+
+	return extract(innerMsgIndex, eventTypes, eventTypesNoTransfer, parsedEvents)
+}
+
+func MsgFundCommunityPool(parsedEvents *utils.ParsedTxsResultsEvents,
+	innerMsgIndex int,
+) []model.BlockResultsEvent {
+	eventTypes := []string{"coin_spent", "coin_received", "transfer", "message"}
+
+	eventTypesNoTransfer := []string{"message"}
+
+	return extract(innerMsgIndex, eventTypes, eventTypesNoTransfer, parsedEvents)
+}
+
+func extract(innerMsgIndex int, eventTypes []string, eventTypesRetry []string, parsedEvents *utils.ParsedTxsResultsEvents) []model.BlockResultsEvent {
+	// extract events
+	extractedEvents := getMsgEvents(innerMsgIndex, eventTypes, parsedEvents)
+
+	// retry
+	if len(extractedEvents) <= 0 {
+		extractedEvents = getMsgEvents(innerMsgIndex, eventTypesRetry, parsedEvents)
+	}
+
+	return extractedEvents
+}
+
+func getMsgEvents(innerMsgIndex int, eventTypes []string, parsedEvents *utils.ParsedTxsResultsEvents) []model.BlockResultsEvent {
+	var extractedEvents []model.BlockResultsEvent
+
+	for _, eventType := range eventTypes {
+
+		events := parsedEvents.GetRawEvents()
+
+		for _, event := range events {
+			splitBykey := utils.NewParsedTxsResultLogEventsSplitByKey(&event)
+
+			if len(splitBykey)-1 >= innerMsgIndex {
+
+				rawEvent := splitBykey[innerMsgIndex].GetRawEvents()
+				keyIndex := splitBykey[innerMsgIndex].GetKeyIndex()
+
+				var extractedAttributes model.BlockResultsEvent
+
+				for _, key := range keyIndex {
+					extractedAttributes.Type = rawEvent.Type
+					extractedAttributes.Attributes = append(extractedAttributes.Attributes, rawEvent.Attributes[key])
+				}
+
+				// check attribute key
+				if rawEvent.Type == eventType {
+					extractedEvents = append(extractedEvents, extractedAttributes)
+
+				}
+			}
+		}
+	}
+
+	return extractedEvents
+}

--- a/usecase/parser/msg.go
+++ b/usecase/parser/msg.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"time"
@@ -121,8 +122,7 @@ func ParseBlockTxsMsgToCommands(
 				// cosmos authz
 				"/cosmos.authz.v1beta1.MsgGrant",
 				"/cosmos.authz.v1beta1.MsgRevoke",
-				// FIXME: https://github.com/crypto-com/chain-indexing/issues/673
-				//"/cosmos.authz.v1beta1.MsgExec",
+				"/cosmos.authz.v1beta1.MsgExec",
 
 				// cosmos feegrant
 				"/cosmos.feegrant.v1beta1.MsgGrantAllowance",
@@ -259,6 +259,7 @@ func ParseMsgWithdrawDelegatorReward(
 			},
 		)}, possibleSignerAddresses
 	}
+
 	log := utils.NewParsedTxsResultLog(&parserParams.TxsResult.Log[parserParams.MsgIndex])
 	var recipient string
 	var amount coin.Coins
@@ -1618,7 +1619,9 @@ func parseMsgExecInnerMsgs(
 		panic(fmt.Errorf("error parsing MsgExec.msgs to []interface{}: %v", parserParams.Msg["msgs"]))
 	}
 
+	txLog := parserParams.TxsResult.Log
 	for innerMsgIndex, innerMsgInterface := range msgs {
+		parserParams.TxsResult.Log = txLog
 		innerMsg, ok := innerMsgInterface.(map[string]interface{})
 		if !ok {
 			panic(fmt.Errorf("error parsing MsgExec.msgs[%v] to map[string]interface{}: %v", innerMsgIndex, innerMsgInterface))
@@ -1631,13 +1634,19 @@ func parseMsgExecInnerMsgs(
 
 		parser := parserParams.ParserManager.GetParser(utils.CosmosParserKey(innerMsgType), utils.ParserBlockHeight(blockHeight))
 
+		parserParams.TxsResult.Log = ParseTxsResultsEvents(innerMsgType, parserParams.TxsResult.Log[parserParams.MsgCommonParams.MsgIndex], innerMsgIndex)
+
+		bytes, _ := json.Marshal(parserParams.TxsResult.Log)
+		rawLog, _ := json.Marshal(bytes)
+		parserParams.TxsResult.RawLog = string(rawLog)
+
 		msgCommands, _ := parser(utils.CosmosParserParams{
 			AddressPrefix:   parserParams.AddressPrefix,
 			StakingDenom:    parserParams.StakingDenom,
 			TxsResult:       parserParams.TxsResult,
 			MsgCommonParams: parserParams.MsgCommonParams,
 			Msg:             innerMsg,
-			MsgIndex:        parserParams.MsgIndex,
+			MsgIndex:        0,
 			ParserManager:   parserParams.ParserManager,
 		})
 		commands = append(commands, msgCommands...)

--- a/usecase/parser/msg_exec_test.go
+++ b/usecase/parser/msg_exec_test.go
@@ -12,11 +12,12 @@ import (
 	"github.com/crypto-com/chain-indexing/usecase/event"
 	"github.com/crypto-com/chain-indexing/usecase/parser"
 	usecase_parser_test "github.com/crypto-com/chain-indexing/usecase/parser/test"
+	usecase_parser_test_msg_exec "github.com/crypto-com/chain-indexing/usecase/parser/test/tx_msg_exec"
 	"github.com/crypto-com/chain-indexing/usecase/parser/utils"
 )
 
 var _ = Describe("ParseMsgCommands", func() {
-	XDescribe("MsgExec", func() {
+	Describe("MsgExec", func() {
 		It("should parse Msg commands when there is MsgExec (inner message MsgSend) in the transaction", func() {
 			expected := `{
             "name": "MsgExecCreated",
@@ -57,10 +58,10 @@ var _ = Describe("ParseMsgCommands", func() {
 
 			txDecoder := utils.NewTxDecoder()
 			block, _, _ := tendermint.ParseBlockResp(strings.NewReader(
-				usecase_parser_test.TX_MSG_EXEC_MSG_SEND_BLOCK_RESP,
+				usecase_parser_test_msg_exec.TX_MSG_EXEC_MSG_SEND_BLOCK_RESP,
 			))
 			blockResults, _ := tendermint.ParseBlockResultsResp(strings.NewReader(
-				usecase_parser_test.TX_MSG_EXEC_MSG_SEND_BLOCK_RESULTS_RESP,
+				usecase_parser_test_msg_exec.TX_MSG_EXEC_MSG_SEND_BLOCK_RESULTS_RESP,
 			))
 
 			accountAddressPrefix := "cro"
@@ -145,10 +146,10 @@ var _ = Describe("ParseMsgCommands", func() {
 
 			txDecoder := utils.NewTxDecoder()
 			block, _, _ := tendermint.ParseBlockResp(strings.NewReader(
-				usecase_parser_test.TX_MSG_EXEC_MSG_DELEGATE_BLOCK_RESP,
+				usecase_parser_test_msg_exec.TX_MSG_EXEC_MSG_DELEGATE_BLOCK_RESP,
 			))
 			blockResults, _ := tendermint.ParseBlockResultsResp(strings.NewReader(
-				usecase_parser_test.TX_MSG_EXEC_MSG_DELEGATE_BLOCK_RESULTS_RESP,
+				usecase_parser_test_msg_exec.TX_MSG_EXEC_MSG_DELEGATE_BLOCK_RESULTS_RESP,
 			))
 
 			accountAddressPrefix := "cro"
@@ -199,6 +200,668 @@ var _ = Describe("ParseMsgCommands", func() {
 				),
 			))
 			Expect(possibleSignerAddresses).To(Equal([]string{"tcro15zh5tn7xjdecu4zjclsmlnlht5ead2mx84gau2"}))
+
+		})
+
+		It("should parse Msg commands when there is MsgExec (inner message MsgSetWithdrawAddress) in the transaction", func() {
+			expected := `
+			{
+				"name": "MsgExecCreated",
+				"version": 1,
+				"height": 292,
+				"uuid": "{UUID}",
+				"msgName": "MsgExec",
+				"txHash": "2DFF941C55DCA1FCDBDB7F38F84C9C7810C1E9F4709682D0570964D2BB79CD82",
+				"msgIndex": 0,
+				"params": {
+					"@type": "/cosmos.authz.v1beta1.MsgExec",
+					"grantee": "cro1406y009n43awa0e5n6t2t06a8tty9azpu9at25",
+					"msgs": [
+						{
+							"@type": "/cosmos.distribution.v1beta1.MsgSetWithdrawAddress"
+						}
+					]
+				}
+			}
+			`
+
+			expectedInnerMsg := []string{`
+			{
+				"name": "MsgSetWithdrawAddressCreated",
+				"version": 1,
+				"height": 292,
+				"uuid": "{UUID}",
+				"msgName": "MsgSetWithdrawAddress",
+				"txHash": "2DFF941C55DCA1FCDBDB7F38F84C9C7810C1E9F4709682D0570964D2BB79CD82",
+				"msgIndex": 0,
+				"delegatorAddress": "cro1htqsxfj4k9hhagtvlmqx6l4j593pzdk7ddv50n",
+				"withdrawAddress": "cro1406y009n43awa0e5n6t2t06a8tty9azpu9at25"
+			}`}
+
+			txDecoder := utils.NewTxDecoder()
+			block, _, _ := tendermint.ParseBlockResp(strings.NewReader(
+				usecase_parser_test_msg_exec.TX_MSG_EXEC_MSG_SET_WITHDRAW_ADDRESS_BLOCK_RESP,
+			))
+			blockResults, _ := tendermint.ParseBlockResultsResp(strings.NewReader(
+				usecase_parser_test_msg_exec.TX_MSG_EXEC_MSG_SET_WITHDRAW_ADDRESS_BLOCK_RESULTS_RESP,
+			))
+
+			accountAddressPrefix := "cro"
+			stakingDenom := "basecro"
+
+			pm := usecase_parser_test.InitParserManager()
+
+			cmds, possibleSignerAddresses, err := parser.ParseBlockTxsMsgToCommands(
+				pm,
+				txDecoder,
+				block,
+				blockResults,
+				accountAddressPrefix,
+				stakingDenom,
+			)
+			Expect(err).To(BeNil())
+			Expect(cmds).To(HaveLen(2))
+
+			cmd := cmds[0]
+			Expect(cmd.Name()).To(Equal("CreateMsgExec"))
+
+			untypedEvent, _ := cmd.Exec()
+			createMsgExecEvent := untypedEvent.(*event.MsgExec)
+			regex, _ := regexp.Compile("\n?\r?\\s?")
+
+			Expect(json.MustMarshalToString(createMsgExecEvent)).To(Equal(
+				strings.Replace(
+					regex.ReplaceAllString(expected, ""),
+					"{UUID}",
+					createMsgExecEvent.UUID(),
+					-1,
+				),
+			))
+
+			innerCmd := cmds[1]
+			Expect(innerCmd.Name()).To(Equal("CreateMsgSetWithdrawAddress"))
+
+			untypedInnerEvent, _ := innerCmd.Exec()
+			createMsgSetWithdrawAddressEvent := untypedInnerEvent.(*event.MsgSetWithdrawAddress)
+
+			Expect(json.MustMarshalToString(createMsgSetWithdrawAddressEvent)).To(Equal(
+				strings.Replace(
+					regex.ReplaceAllString(expectedInnerMsg[0], ""),
+					"{UUID}",
+					createMsgSetWithdrawAddressEvent.UUID(),
+					-1,
+				),
+			))
+
+			Expect(possibleSignerAddresses).To(Equal([]string{"cro1406y009n43awa0e5n6t2t06a8tty9azpu9at25"}))
+
+		})
+
+		It("should parse Msg commands when there is MsgExec (inner message MsgWithdrawDelegatorReward) in the transaction", func() {
+			expected := `
+			{
+				"name": "MsgExecCreated",
+				"version": 1,
+				"height": 313,
+				"uuid": "{UUID}",
+				"msgName": "MsgExec",
+				"txHash": "711F6ED876F2EDDF927E8330621D734B1661D2A26132CFF141C9399266564176",
+				"msgIndex": 0,
+				"params": {
+					"@type": "/cosmos.authz.v1beta1.MsgExec",
+					"grantee": "cro1htqsxfj4k9hhagtvlmqx6l4j593pzdk7ddv50n",
+					"msgs": [
+						{
+							"@type": "/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward"
+						},
+						{
+							"@type": "/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward"
+						}
+					]
+				}
+			}
+			`
+
+			expectedInnerMsg := []string{`
+			{
+				"name": "MsgWithdrawDelegatorRewardCreated",
+				"version": 1,
+				"height": 313,
+				"uuid": "{UUID}",
+				"msgName": "MsgWithdrawDelegatorReward",
+				"txHash": "711F6ED876F2EDDF927E8330621D734B1661D2A26132CFF141C9399266564176",
+				"msgIndex": 0,
+				"delegatorAddress": "cro1htqsxfj4k9hhagtvlmqx6l4j593pzdk7ddv50n",
+				"validatorAddress": "crocncl1htqsxfj4k9hhagtvlmqx6l4j593pzdk7wq0ad0",
+				"recipientAddress": "cro1htqsxfj4k9hhagtvlmqx6l4j593pzdk7ddv50n",
+				"amount": [
+					{
+						"denom": "basecro",
+						"amount": "362332"
+					}
+				]
+			}`,
+				`{
+				"name": "MsgWithdrawDelegatorRewardCreated",
+				"version": 1,
+				"height": 313,
+				"uuid": "{UUID}",
+				"msgName": "MsgWithdrawDelegatorReward",
+				"txHash": "711F6ED876F2EDDF927E8330621D734B1661D2A26132CFF141C9399266564176",
+				"msgIndex": 0,
+				"delegatorAddress": "cro1htqsxfj4k9hhagtvlmqx6l4j593pzdk7ddv50n",
+				"validatorAddress": "crocncl17cye5gmealmpgz3tclfjga7urdjxj6nah3u8w2",
+				"recipientAddress": "cro1htqsxfj4k9hhagtvlmqx6l4j593pzdk7ddv50n",
+				"amount": []
+			}`}
+
+			txDecoder := utils.NewTxDecoder()
+			block, _, _ := tendermint.ParseBlockResp(strings.NewReader(
+				usecase_parser_test_msg_exec.TX_MSG_EXEC_MSG_WITHDRAW_DELEGATOR_REWARD_BLOCK_RESP,
+			))
+			blockResults, _ := tendermint.ParseBlockResultsResp(strings.NewReader(
+				usecase_parser_test_msg_exec.TX_MSG_EXEC_MSG_WITHDRAW_DELEGATOR_REWARD_BLOCK_RESULTS_RESP,
+			))
+
+			accountAddressPrefix := "cro"
+			stakingDenom := "basecro"
+
+			pm := usecase_parser_test.InitParserManager()
+
+			cmds, possibleSignerAddresses, err := parser.ParseBlockTxsMsgToCommands(
+				pm,
+				txDecoder,
+				block,
+				blockResults,
+				accountAddressPrefix,
+				stakingDenom,
+			)
+			Expect(err).To(BeNil())
+			Expect(cmds).To(HaveLen(3))
+
+			cmd := cmds[0]
+			Expect(cmd.Name()).To(Equal("CreateMsgExec"))
+
+			untypedEvent, _ := cmd.Exec()
+			createMsgExecEvent := untypedEvent.(*event.MsgExec)
+			regex, _ := regexp.Compile("\n?\r?\\s?")
+
+			Expect(json.MustMarshalToString(createMsgExecEvent)).To(Equal(
+				strings.Replace(
+					regex.ReplaceAllString(expected, ""),
+					"{UUID}",
+					createMsgExecEvent.UUID(),
+					-1,
+				),
+			))
+
+			innerCmd := cmds[1]
+			Expect(innerCmd.Name()).To(Equal("CreateMsgWithdrawDelegatorReward"))
+
+			untypedInnerEvent, _ := innerCmd.Exec()
+			createMsgWithdrawDelegatorRewardEvent := untypedInnerEvent.(*event.MsgWithdrawDelegatorReward)
+			Expect(json.MustMarshalToString(createMsgWithdrawDelegatorRewardEvent)).To(Equal(
+				strings.Replace(
+					regex.ReplaceAllString(expectedInnerMsg[0], ""),
+					"{UUID}",
+					createMsgWithdrawDelegatorRewardEvent.UUID(),
+					-1,
+				),
+			))
+
+			innerCmd = cmds[2]
+			Expect(innerCmd.Name()).To(Equal("CreateMsgWithdrawDelegatorReward"))
+
+			untypedInnerEvent, _ = innerCmd.Exec()
+			createMsgWithdrawDelegatorRewardEvent = untypedInnerEvent.(*event.MsgWithdrawDelegatorReward)
+
+			Expect(json.MustMarshalToString(createMsgWithdrawDelegatorRewardEvent)).To(Equal(
+				strings.Replace(
+					regex.ReplaceAllString(expectedInnerMsg[1], ""),
+					"{UUID}",
+					createMsgWithdrawDelegatorRewardEvent.UUID(),
+					-1,
+				),
+			))
+			Expect(possibleSignerAddresses).To(Equal([]string{"cro1htqsxfj4k9hhagtvlmqx6l4j593pzdk7ddv50n"}))
+
+		})
+
+		It("should parse Msg commands when there is MsgExec (inner message MsgWithdrawValidatorCommission) in the transaction", func() {
+			expected := `
+			{
+				"name": "MsgExecCreated",
+				"version": 1,
+				"height": 5991,
+				"uuid": "{UUID}",
+				"msgName": "MsgExec",
+				"txHash": "575DE51BFF24CEE75654C1BE8EFE30B01E9269E58267A27B53F5338457B9B870",
+				"msgIndex": 0,
+				"params": {
+					"@type": "/cosmos.authz.v1beta1.MsgExec",
+					"grantee": "cro1406y009n43awa0e5n6t2t06a8tty9azpu9at25",
+					"msgs": [
+						{
+							"@type": "/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward"
+						},
+						{
+							"@type": "/cosmos.distribution.v1beta1.MsgWithdrawValidatorCommission"
+						}
+					]
+				}
+			}
+			`
+
+			expectedInnerMsg := []string{`
+			{
+				"name": "MsgWithdrawDelegatorRewardCreated",
+				"version": 1,
+				"height": 5991,
+				"uuid": "{UUID}",
+				"msgName": "MsgWithdrawDelegatorReward",
+				"txHash": "575DE51BFF24CEE75654C1BE8EFE30B01E9269E58267A27B53F5338457B9B870",
+				"msgIndex": 0,
+				"delegatorAddress": "cro1htqsxfj4k9hhagtvlmqx6l4j593pzdk7ddv50n",
+				"validatorAddress": "crocncl1htqsxfj4k9hhagtvlmqx6l4j593pzdk7wq0ad0",
+				"recipientAddress": "cro1htqsxfj4k9hhagtvlmqx6l4j593pzdk7ddv50n",
+				"amount": [
+					{
+						"denom": "basecro",
+						"amount": "1285329"
+					}
+				]
+			}`,
+				`{
+				"name": "MsgWithdrawValidatorCommissionCreated",
+				"version": 1,
+				"height": 5991,
+				"uuid": "{UUID}",
+				"msgName": "MsgWithdrawValidatorCommission",
+				"txHash": "575DE51BFF24CEE75654C1BE8EFE30B01E9269E58267A27B53F5338457B9B870",
+				"msgIndex": 0,
+				"validatorAddress": "crocncl1htqsxfj4k9hhagtvlmqx6l4j593pzdk7wq0ad0",
+				"recipientAddress": "cro1htqsxfj4k9hhagtvlmqx6l4j593pzdk7ddv50n",
+				"amount": [
+					{
+						"denom": "basecro",
+						"amount": "142814"
+					}
+				]
+			}`}
+
+			txDecoder := utils.NewTxDecoder()
+			block, _, _ := tendermint.ParseBlockResp(strings.NewReader(
+				usecase_parser_test_msg_exec.TX_MSG_EXEC_MSG_WITHDRAW_VALIDATOR_COMMISSION_BLOCK_RESP,
+			))
+			blockResults, _ := tendermint.ParseBlockResultsResp(strings.NewReader(
+				usecase_parser_test_msg_exec.TX_MSG_EXEC_MSG_WITHDRAW_VALIDATOR_COMMISSION_BLOCK_RESULTS_RESP,
+			))
+
+			accountAddressPrefix := "cro"
+			stakingDenom := "basecro"
+
+			pm := usecase_parser_test.InitParserManager()
+
+			cmds, possibleSignerAddresses, err := parser.ParseBlockTxsMsgToCommands(
+				pm,
+				txDecoder,
+				block,
+				blockResults,
+				accountAddressPrefix,
+				stakingDenom,
+			)
+			Expect(err).To(BeNil())
+			Expect(cmds).To(HaveLen(3))
+
+			cmd := cmds[0]
+			Expect(cmd.Name()).To(Equal("CreateMsgExec"))
+
+			untypedEvent, _ := cmd.Exec()
+			createMsgExecEvent := untypedEvent.(*event.MsgExec)
+			regex, _ := regexp.Compile("\n?\r?\\s?")
+
+			Expect(json.MustMarshalToString(createMsgExecEvent)).To(Equal(
+				strings.Replace(
+					regex.ReplaceAllString(expected, ""),
+					"{UUID}",
+					createMsgExecEvent.UUID(),
+					-1,
+				),
+			))
+
+			innerCmd := cmds[1]
+			Expect(innerCmd.Name()).To(Equal("CreateMsgWithdrawDelegatorReward"))
+
+			untypedInnerEvent, _ := innerCmd.Exec()
+			createMsgWithdrawDelegatorRewardEvent := untypedInnerEvent.(*event.MsgWithdrawDelegatorReward)
+			Expect(json.MustMarshalToString(createMsgWithdrawDelegatorRewardEvent)).To(Equal(
+				strings.Replace(
+					regex.ReplaceAllString(expectedInnerMsg[0], ""),
+					"{UUID}",
+					createMsgWithdrawDelegatorRewardEvent.UUID(),
+					-1,
+				),
+			))
+
+			innerCmd = cmds[2]
+			Expect(innerCmd.Name()).To(Equal("CreateMsgWithdrawValidatorCommission"))
+
+			untypedInnerEvent, _ = innerCmd.Exec()
+			createMsgWithdrawValidatorCommissionEvent := untypedInnerEvent.(*event.MsgWithdrawValidatorCommission)
+
+			Expect(json.MustMarshalToString(createMsgWithdrawValidatorCommissionEvent)).To(Equal(
+				strings.Replace(
+					regex.ReplaceAllString(expectedInnerMsg[1], ""),
+					"{UUID}",
+					createMsgWithdrawValidatorCommissionEvent.UUID(),
+					-1,
+				),
+			))
+			Expect(possibleSignerAddresses).To(Equal([]string{"cro1406y009n43awa0e5n6t2t06a8tty9azpu9at25"}))
+
+		})
+
+		It("should parse Msg commands when there is MsgExec (inner message MsgFundCommunityPool) in the transaction", func() {
+			expected := `
+			{
+				"name": "MsgExecCreated",
+				"version": 1,
+				"height": 2569,
+				"uuid": "{UUID}",
+				"msgName": "MsgExec",
+				"txHash": "6628CBD728424C24B58E1598800DFFB7FCD8CBECD212925171E933980B8E7143",
+				"msgIndex": 0,
+				"params": {
+					"@type": "/cosmos.authz.v1beta1.MsgExec",
+					"grantee": "cro1406y009n43awa0e5n6t2t06a8tty9azpu9at25",
+					"msgs": [
+						{
+							"@type": "/cosmos.distribution.v1beta1.MsgFundCommunityPool"
+						},
+						{
+							"@type": "/cosmos.distribution.v1beta1.MsgFundCommunityPool"
+						}
+					]
+				}
+			}
+			`
+
+			expectedInnerMsg := []string{`
+			{
+				"name": "MsgFundCommunityPoolCreated",
+				"version": 1,
+				"height": 2569,
+				"uuid": "{UUID}",
+				"msgName": "MsgFundCommunityPool",
+				"txHash": "6628CBD728424C24B58E1598800DFFB7FCD8CBECD212925171E933980B8E7143",
+				"msgIndex": 0,
+				"depositor": "cro1htqsxfj4k9hhagtvlmqx6l4j593pzdk7ddv50n",
+				"amount": [
+					{
+						"denom": "basecro",
+						"amount": "10"
+					}
+				]
+			}`,
+				`{
+				"name": "MsgFundCommunityPoolCreated",
+				"version": 1,
+				"height": 2569,
+				"uuid": "{UUID}",
+				"msgName": "MsgFundCommunityPool",
+				"txHash": "6628CBD728424C24B58E1598800DFFB7FCD8CBECD212925171E933980B8E7143",
+				"msgIndex": 0,
+				"depositor": "cro1htqsxfj4k9hhagtvlmqx6l4j593pzdk7ddv50n",
+				"amount": [
+					{
+						"denom": "basecro",
+						"amount": "11"
+					}
+				]
+			}`}
+
+			txDecoder := utils.NewTxDecoder()
+			block, _, _ := tendermint.ParseBlockResp(strings.NewReader(
+				usecase_parser_test_msg_exec.TX_MSG_EXEC_MSG_FUND_COMMUNITY_POOL_BLOCK_RESP,
+			))
+			blockResults, _ := tendermint.ParseBlockResultsResp(strings.NewReader(
+				usecase_parser_test_msg_exec.TX_MSG_EXEC_MSG_FUND_COMMUNITY_POOL_BLOCK_RESULTS_RESP,
+			))
+
+			accountAddressPrefix := "cro"
+			stakingDenom := "basecro"
+
+			pm := usecase_parser_test.InitParserManager()
+
+			cmds, possibleSignerAddresses, err := parser.ParseBlockTxsMsgToCommands(
+				pm,
+				txDecoder,
+				block,
+				blockResults,
+				accountAddressPrefix,
+				stakingDenom,
+			)
+			Expect(err).To(BeNil())
+			Expect(cmds).To(HaveLen(3))
+
+			cmd := cmds[0]
+			Expect(cmd.Name()).To(Equal("CreateMsgExec"))
+
+			untypedEvent, _ := cmd.Exec()
+			createMsgExecEvent := untypedEvent.(*event.MsgExec)
+			regex, _ := regexp.Compile("\n?\r?\\s?")
+
+			Expect(json.MustMarshalToString(createMsgExecEvent)).To(Equal(
+				strings.Replace(
+					regex.ReplaceAllString(expected, ""),
+					"{UUID}",
+					createMsgExecEvent.UUID(),
+					-1,
+				),
+			))
+
+			innerCmd := cmds[1]
+			Expect(innerCmd.Name()).To(Equal("CreateMsgFundCommunityPool"))
+
+			untypedInnerEvent, _ := innerCmd.Exec()
+			createMsgFundCommunityPoolEvent := untypedInnerEvent.(*event.MsgFundCommunityPool)
+
+			Expect(json.MustMarshalToString(createMsgFundCommunityPoolEvent)).To(Equal(
+				strings.Replace(
+					regex.ReplaceAllString(expectedInnerMsg[0], ""),
+					"{UUID}",
+					createMsgFundCommunityPoolEvent.UUID(),
+					-1,
+				),
+			))
+
+			innerCmd = cmds[2]
+			Expect(innerCmd.Name()).To(Equal("CreateMsgFundCommunityPool"))
+
+			untypedInnerEvent, _ = innerCmd.Exec()
+			createMsgFundCommunityPoolEvent = untypedInnerEvent.(*event.MsgFundCommunityPool)
+
+			Expect(json.MustMarshalToString(createMsgFundCommunityPoolEvent)).To(Equal(
+				strings.Replace(
+					regex.ReplaceAllString(expectedInnerMsg[1], ""),
+					"{UUID}",
+					createMsgFundCommunityPoolEvent.UUID(),
+					-1,
+				),
+			))
+			Expect(possibleSignerAddresses).To(Equal([]string{"cro1406y009n43awa0e5n6t2t06a8tty9azpu9at25"}))
+
+		})
+
+		It("should parse Msg commands when there are two MsgExec in the transaction", func() {
+
+			expected := `
+			{
+				"name": "MsgExecCreated",
+				"version": 1,
+				"height": 386,
+				"uuid": "{UUID}",
+				"msgName": "MsgExec",
+				"txHash": "4A1DC2FE28E63C23BC5DA89FBAD1ECD62868B21E7B097300B5C064F1985CD9D4",
+				"msgIndex": 0,
+				"params": {
+					"@type": "/cosmos.authz.v1beta1.MsgExec",
+					"grantee": "cro1406y009n43awa0e5n6t2t06a8tty9azpu9at25",
+					"msgs": [
+						{
+							"@type": "/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward"
+						}
+					]
+				}
+			}
+			`
+
+			expectedInnerMsg :=
+				`{
+				"name": "MsgWithdrawDelegatorRewardCreated",
+				"version": 1,
+				"height": 386,
+				"uuid": "{UUID}",
+				"msgName": "MsgWithdrawDelegatorReward",
+				"txHash": "4A1DC2FE28E63C23BC5DA89FBAD1ECD62868B21E7B097300B5C064F1985CD9D4",
+				"msgIndex": 0,
+				"delegatorAddress": "cro1htqsxfj4k9hhagtvlmqx6l4j593pzdk7ddv50n",
+				"validatorAddress": "crocncl1htqsxfj4k9hhagtvlmqx6l4j593pzdk7wq0ad0",
+				"recipientAddress": "cro1htqsxfj4k9hhagtvlmqx6l4j593pzdk7ddv50n",
+				"amount": [
+					{
+						"denom": "basecro",
+						"amount": "513305"
+					}
+				]
+			}`
+
+			expected2 := `
+			{
+				"name": "MsgExecCreated",
+				"version": 1,
+				"height": 386,
+				"uuid": "{UUID}",
+				"msgName": "MsgExec",
+				"txHash": "4A1DC2FE28E63C23BC5DA89FBAD1ECD62868B21E7B097300B5C064F1985CD9D4",
+				"msgIndex": 1,
+				"params": {
+					"@type": "/cosmos.authz.v1beta1.MsgExec",
+					"grantee": "cro1406y009n43awa0e5n6t2t06a8tty9azpu9at25",
+					"msgs": [
+						{
+							"@type": "/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward"
+						}
+					]
+				}
+			}
+			`
+
+			expectedInnerMsg2 :=
+				`{
+				"name": "MsgWithdrawDelegatorRewardCreated",
+				"version": 1,
+				"height": 386,
+				"uuid": "{UUID}",
+				"msgName": "MsgWithdrawDelegatorReward",
+				"txHash": "4A1DC2FE28E63C23BC5DA89FBAD1ECD62868B21E7B097300B5C064F1985CD9D4",
+				"msgIndex": 1,
+				"delegatorAddress": "cro1htqsxfj4k9hhagtvlmqx6l4j593pzdk7ddv50n",
+				"validatorAddress": "crocncl17cye5gmealmpgz3tclfjga7urdjxj6nah3u8w2",
+				"recipientAddress": "cro1htqsxfj4k9hhagtvlmqx6l4j593pzdk7ddv50n",
+				"amount": []
+			}`
+
+			txDecoder := utils.NewTxDecoder()
+			block, _, _ := tendermint.ParseBlockResp(strings.NewReader(
+				usecase_parser_test_msg_exec.TX_MSG_EXEC_MULT_WITHDRAW_DELEGATOR_REWARD_BLOCK_RESP,
+			))
+			blockResults, _ := tendermint.ParseBlockResultsResp(strings.NewReader(
+				usecase_parser_test_msg_exec.TX_MSG_EXEC_MULT_WITHDRAW_DELEGATOR_REWARD_RESULTS_RESP,
+			))
+
+			accountAddressPrefix := "cro"
+			stakingDenom := "basecro"
+
+			pm := usecase_parser_test.InitParserManager()
+
+			cmds, possibleSignerAddresses, err := parser.ParseBlockTxsMsgToCommands(
+				pm,
+				txDecoder,
+				block,
+				blockResults,
+				accountAddressPrefix,
+				stakingDenom,
+			)
+
+			Expect(err).To(BeNil())
+			Expect(cmds).To(HaveLen(4))
+
+			cmd := cmds[0]
+			Expect(cmd.Name()).To(Equal("CreateMsgExec"))
+
+			untypedEvent, _ := cmd.Exec()
+			createMsgExecEvent := untypedEvent.(*event.MsgExec)
+
+			regex, _ := regexp.Compile("\n?\r?\\s?")
+
+			Expect(json.MustMarshalToString(createMsgExecEvent)).To(Equal(
+				strings.Replace(
+					regex.ReplaceAllString(expected, ""),
+					"{UUID}",
+					createMsgExecEvent.UUID(),
+					-1,
+				),
+			))
+
+			innerCmd := cmds[1]
+			Expect(innerCmd.Name()).To(Equal("CreateMsgWithdrawDelegatorReward"))
+
+			untypedInnerEvent, _ := innerCmd.Exec()
+			createMsgWithdrawDelegatorRewardEvent := untypedInnerEvent.(*event.MsgWithdrawDelegatorReward)
+
+			Expect(json.MustMarshalToString(createMsgWithdrawDelegatorRewardEvent)).To(Equal(
+				strings.Replace(
+					regex.ReplaceAllString(expectedInnerMsg, ""),
+					"{UUID}",
+					createMsgWithdrawDelegatorRewardEvent.UUID(),
+					-1,
+				),
+			))
+
+			cmd = cmds[2]
+			Expect(cmd.Name()).To(Equal("CreateMsgExec"))
+
+			untypedEvent, _ = cmd.Exec()
+			createMsgExecEvent = untypedEvent.(*event.MsgExec)
+
+			regex, _ = regexp.Compile("\n?\r?\\s?")
+
+			Expect(json.MustMarshalToString(createMsgExecEvent)).To(Equal(
+				strings.Replace(
+					regex.ReplaceAllString(expected2, ""),
+					"{UUID}",
+					createMsgExecEvent.UUID(),
+					-1,
+				),
+			))
+
+			innerCmd = cmds[3]
+			Expect(innerCmd.Name()).To(Equal("CreateMsgWithdrawDelegatorReward"))
+
+			untypedInnerEvent, _ = innerCmd.Exec()
+			createMsgWithdrawDelegatorRewardEvent = untypedInnerEvent.(*event.MsgWithdrawDelegatorReward)
+
+			Expect(json.MustMarshalToString(createMsgWithdrawDelegatorRewardEvent)).To(Equal(
+				strings.Replace(
+					regex.ReplaceAllString(expectedInnerMsg2, ""),
+					"{UUID}",
+					createMsgWithdrawDelegatorRewardEvent.UUID(),
+					-1,
+				),
+			))
+
+			Expect(possibleSignerAddresses).To(Equal([]string{"cro1406y009n43awa0e5n6t2t06a8tty9azpu9at25", "cro1406y009n43awa0e5n6t2t06a8tty9azpu9at25"}))
 
 		})
 	})

--- a/usecase/parser/register.go
+++ b/usecase/parser/register.go
@@ -69,8 +69,7 @@ func InitParsers(manager *utils.CosmosParserManager) {
 	// cosmos authz
 	manager.RegisterParser("/cosmos.authz.v1beta1.MsgGrant", BEGIN_BLOCK_HEIGHT, ParseMsgGrant)
 	manager.RegisterParser("/cosmos.authz.v1beta1.MsgRevoke", BEGIN_BLOCK_HEIGHT, ParseMsgRevoke)
-	// FIXME: https://github.com/crypto-com/chain-indexing/issues/673
-	//manager.RegisterParser("/cosmos.authz.v1beta1.MsgExec", BEGIN_BLOCK_HEIGHT, ParseMsgExec)
+	manager.RegisterParser("/cosmos.authz.v1beta1.MsgExec", BEGIN_BLOCK_HEIGHT, ParseMsgExec)
 
 	// cosmos feegrant
 	manager.RegisterParser("/cosmos.feegrant.v1beta1.MsgGrantAllowance", BEGIN_BLOCK_HEIGHT, ParseMsgGrantAllowance)

--- a/usecase/parser/test/tx_msg_exec/tx_msg_exec_msg_delegate.go
+++ b/usecase/parser/test/tx_msg_exec/tx_msg_exec_msg_delegate.go
@@ -1,0 +1,600 @@
+package usecase_parser_test
+
+const TX_MSG_EXEC_MSG_DELEGATE_BLOCK_RESP = `
+{
+  "jsonrpc": "2.0",
+  "id": -1,
+  "result": {
+    "block_id": {
+      "hash": "A7E71E7931CB42BC7BE4A7397D32F9AB5985751B2B053756498601CEAB679AD5",
+      "parts": {
+        "total": 1,
+        "hash": "751231A4D4A9383D8C69497E8B5D9F3BB13A5A77E55376C9641365F8F8DCAB45"
+      }
+    },
+    "block": {
+      "header": {
+        "version": {
+          "block": "11"
+        },
+        "chain_id": "testnet-croeseid-4",
+        "height": "170493",
+        "time": "2021-08-29T17:15:46.150170633Z",
+        "last_block_id": {
+          "hash": "B419EF055C39B597CB3ECF6A62AE588527EDA2BCCA5D96679E02AE292BACAA87",
+          "parts": {
+            "total": 1,
+            "hash": "CB6D2047E8EC5EE8BA1D1A145AD0A181D3335B827BA0C55E956073D9D89FF14F"
+          }
+        },
+        "last_commit_hash": "2B293501E6C1EBB195A4BE5BB6BC3DD002305EBC10D4BF65790F8BB9A983A550",
+        "data_hash": "020E880F725CFBD904B3266E6526258373292D9C26382555E50A0BB529F521E7",
+        "validators_hash": "77B520746A7915359B36FBB0FC761C77528FCB68E5998412B6CCDA1CF6B30FC9",
+        "next_validators_hash": "77B520746A7915359B36FBB0FC761C77528FCB68E5998412B6CCDA1CF6B30FC9",
+        "consensus_hash": "372B4AE845086C837EFEF79A189B085B1FD6610C53F3BEB17EE0E27B347C06DE",
+        "app_hash": "3B0D6B9E55CFE1A7B679F70FCF1E36B5236042200AB344FE2AD363C82C114ED0",
+        "last_results_hash": "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
+        "evidence_hash": "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
+        "proposer_address": "71DA178AE52B2D0654102A86166CE91AC5121CB2"
+      },
+      "data": {
+        "txs": [
+          "CvEBCu4BCh0vY29zbW9zLmF1dGh6LnYxYmV0YTEuTXNnRXhlYxLMAQordGNybzE1emg1dG43eGpkZWN1NHpqY2xzbWxubGh0NWVhZDJteDg0Z2F1MhKcAQojL2Nvc21vcy5zdGFraW5nLnYxYmV0YTEuTXNnRGVsZWdhdGUSdQordGNybzF2dXJmaHFmMGoyamdmcGphaGxqYTZnNnVxMnRzMnI2MHN3bTJkORIvdGNyb2NuY2wxNjN0djU5eXpnZXFjYXA4bHJzYTJyNHprNTgwaDhkZHI1YTBzZGQaFQoIYmFzZXRjcm8SCTEwMDAwMDAwMBJsClAKRgofL2Nvc21vcy5jcnlwdG8uc2VjcDI1NmsxLlB1YktleRIjCiED9mZmspMfOkUd+aX74oneU7ypDKy6DeWzT8xw+LpNjegSBAoCCAEYDhIYChIKCGJhc2V0Y3JvEgYxMDAwMDAQwJoMGkAlVwW36DZkZ3MtfRH2xorcF1N85ubGD1Kgws8+TcDkq1BgaIhBJQmqNu9KpFHprSYAxqY14faXpJgQK55M/o/H"
+        ]
+      },
+      "evidence": {
+        "evidence": []
+      },
+      "last_commit": {
+        "height": "170492",
+        "round": 0,
+        "block_id": {
+          "hash": "B419EF055C39B597CB3ECF6A62AE588527EDA2BCCA5D96679E02AE292BACAA87",
+          "parts": {
+            "total": 1,
+            "hash": "CB6D2047E8EC5EE8BA1D1A145AD0A181D3335B827BA0C55E956073D9D89FF14F"
+          }
+        },
+        "signatures": [
+          {
+            "block_id_flag": 2,
+            "validator_address": "F9A4582896E5F2692BEDDD7C251755E33D2DE013",
+            "timestamp": "2021-08-29T17:15:46.199521055Z",
+            "signature": "m+H5ZtQFrzUxBSs/qQXYGTLVjIIyxGF++kefr6//m9mfKW16mkjqbhZfMYLf209SsosIdUzbA9ahGe1V3kziAQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "71DA178AE52B2D0654102A86166CE91AC5121CB2",
+            "timestamp": "2021-08-29T17:15:46.150170633Z",
+            "signature": "LJ/xK9ZbD6nCCAKQvjWoEErx8IsRZP5JMtNUJ+M/hvGITuz9LwwfxmybMVreKI7miYsZvTNCQb+vKG3e+313BQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "7E2B455523A35AE8F4064C00AF01515FEF673079",
+            "timestamp": "2021-08-29T17:15:46.090847978Z",
+            "signature": "apTaYIh2ueNK2jvBaRKIq5m9p2XtLljc04wfKX6BVBrm6ewR62C49J1jXcBA8Ae99/2bpBfLWuKYLSbo3v/tDA=="
+          }
+        ]
+      }
+    }
+  }
+}
+`
+
+const TX_MSG_EXEC_MSG_DELEGATE_BLOCK_RESULTS_RESP = `
+{
+  "jsonrpc": "2.0",
+  "id": -1,
+  "result": {
+    "height": "170493",
+    "txs_results": [
+      {
+        "code": 0,
+        "data": "CiMKHS9jb3Ntb3MuYXV0aHoudjFiZXRhMS5Nc2dFeGVjEgIKAA==",
+        "log": "[{\"events\":[{\"type\":\"coin_received\",\"attributes\":[{\"key\":\"receiver\",\"value\":\"tcro1fl48vsnmsdzcv85q5d2q4z5ajdha8yu3r4gj9h\"},{\"key\":\"amount\",\"value\":\"100000000basetcro\"}]},{\"type\":\"coin_spent\",\"attributes\":[{\"key\":\"spender\",\"value\":\"tcro1vurfhqf0j2jgfpjahlja6g6uq2ts2r60swm2d9\"},{\"key\":\"amount\",\"value\":\"100000000basetcro\"}]},{\"type\":\"delegate\",\"attributes\":[{\"key\":\"validator\",\"value\":\"tcrocncl163tv59yzgeqcap8lrsa2r4zk580h8ddr5a0sdd\"},{\"key\":\"amount\",\"value\":\"100000000basetcro\"},{\"key\":\"new_shares\",\"value\":\"100000000.000000000000000000\"}]},{\"type\":\"message\",\"attributes\":[{\"key\":\"action\",\"value\":\"/cosmos.authz.v1beta1.MsgExec\"},{\"key\":\"module\",\"value\":\"staking\"},{\"key\":\"sender\",\"value\":\"tcro1vurfhqf0j2jgfpjahlja6g6uq2ts2r60swm2d9\"}]}]}]",
+        "info": "",
+        "gas_wanted": "200000",
+        "gas_used": "120155",
+        "events": [
+          {
+            "type": "coin_spent",
+            "attributes": [
+              {
+                "key": "c3BlbmRlcg==",
+                "value": "dGNybzE1emg1dG43eGpkZWN1NHpqY2xzbWxubGh0NWVhZDJteDg0Z2F1Mg==",
+                "index": true
+              },
+              {
+                "key": "YW1vdW50",
+                "value": "MTAwMDAwYmFzZXRjcm8=",
+                "index": true
+              }
+            ]
+          },
+          {
+            "type": "coin_received",
+            "attributes": [
+              {
+                "key": "cmVjZWl2ZXI=",
+                "value": "dGNybzE3eHBmdmFrbTJhbWc5NjJ5bHM2Zjg0ejNrZWxsOGM1bHhoemFoYQ==",
+                "index": true
+              },
+              {
+                "key": "YW1vdW50",
+                "value": "MTAwMDAwYmFzZXRjcm8=",
+                "index": true
+              }
+            ]
+          },
+          {
+            "type": "transfer",
+            "attributes": [
+              {
+                "key": "cmVjaXBpZW50",
+                "value": "dGNybzE3eHBmdmFrbTJhbWc5NjJ5bHM2Zjg0ejNrZWxsOGM1bHhoemFoYQ==",
+                "index": true
+              },
+              {
+                "key": "c2VuZGVy",
+                "value": "dGNybzE1emg1dG43eGpkZWN1NHpqY2xzbWxubGh0NWVhZDJteDg0Z2F1Mg==",
+                "index": true
+              },
+              {
+                "key": "YW1vdW50",
+                "value": "MTAwMDAwYmFzZXRjcm8=",
+                "index": true
+              }
+            ]
+          },
+          {
+            "type": "message",
+            "attributes": [
+              {
+                "key": "c2VuZGVy",
+                "value": "dGNybzE1emg1dG43eGpkZWN1NHpqY2xzbWxubGh0NWVhZDJteDg0Z2F1Mg==",
+                "index": true
+              }
+            ]
+          },
+          {
+            "type": "tx",
+            "attributes": [
+              {
+                "key": "YWNjX3NlcQ==",
+                "value": "dGNybzE1emg1dG43eGpkZWN1NHpqY2xzbWxubGh0NWVhZDJteDg0Z2F1Mi8xNA==",
+                "index": true
+              }
+            ]
+          },
+          {
+            "type": "tx",
+            "attributes": [
+              {
+                "key": "c2lnbmF0dXJl",
+                "value": "SlZjRnQrZzJaR2R6TFgwUjlzYUszQmRUZk9ibXhnOVNvTUxQUGszQTVLdFFZR2lJUVNVSnFqYnZTcVJSNmEwbUFNYW1OZUgybDZTWUVDdWVUUDZQeHc9PQ==",
+                "index": true
+              }
+            ]
+          },
+          {
+            "type": "message",
+            "attributes": [
+              {
+                "key": "YWN0aW9u",
+                "value": "L2Nvc21vcy5hdXRoei52MWJldGExLk1zZ0V4ZWM=",
+                "index": true
+              }
+            ]
+          },
+          {
+            "type": "coin_spent",
+            "attributes": [
+              {
+                "key": "c3BlbmRlcg==",
+                "value": "dGNybzF2dXJmaHFmMGoyamdmcGphaGxqYTZnNnVxMnRzMnI2MHN3bTJkOQ==",
+                "index": true
+              },
+              {
+                "key": "YW1vdW50",
+                "value": "MTAwMDAwMDAwYmFzZXRjcm8=",
+                "index": true
+              }
+            ]
+          },
+          {
+            "type": "coin_received",
+            "attributes": [
+              {
+                "key": "cmVjZWl2ZXI=",
+                "value": "dGNybzFmbDQ4dnNubXNkemN2ODVxNWQycTR6NWFqZGhhOHl1M3I0Z2o5aA==",
+                "index": true
+              },
+              {
+                "key": "YW1vdW50",
+                "value": "MTAwMDAwMDAwYmFzZXRjcm8=",
+                "index": true
+              }
+            ]
+          },
+          {
+            "type": "delegate",
+            "attributes": [
+              {
+                "key": "dmFsaWRhdG9y",
+                "value": "dGNyb2NuY2wxNjN0djU5eXpnZXFjYXA4bHJzYTJyNHprNTgwaDhkZHI1YTBzZGQ=",
+                "index": true
+              },
+              {
+                "key": "YW1vdW50",
+                "value": "MTAwMDAwMDAwYmFzZXRjcm8=",
+                "index": true
+              },
+              {
+                "key": "bmV3X3NoYXJlcw==",
+                "value": "MTAwMDAwMDAwLjAwMDAwMDAwMDAwMDAwMDAwMA==",
+                "index": true
+              }
+            ]
+          },
+          {
+            "type": "message",
+            "attributes": [
+              {
+                "key": "bW9kdWxl",
+                "value": "c3Rha2luZw==",
+                "index": true
+              },
+              {
+                "key": "c2VuZGVy",
+                "value": "dGNybzF2dXJmaHFmMGoyamdmcGphaGxqYTZnNnVxMnRzMnI2MHN3bTJkOQ==",
+                "index": true
+              }
+            ]
+          }
+        ],
+        "codespace": ""
+      }
+    ],
+    "begin_block_events": [
+      {
+        "type": "coin_received",
+        "attributes": [
+          {
+            "key": "cmVjZWl2ZXI=",
+            "value": "dGNybzFtM2gzMHdsdnNmOGxscnV4dHB1a2R2c3kwa20ya3VtODdseDltcQ==",
+            "index": true
+          },
+          {
+            "key": "YW1vdW50",
+            "value": "NDg1NzQwNDAwMWJhc2V0Y3Jv",
+            "index": true
+          }
+        ]
+      },
+      {
+        "type": "coinbase",
+        "attributes": [
+          {
+            "key": "bWludGVy",
+            "value": "dGNybzFtM2gzMHdsdnNmOGxscnV4dHB1a2R2c3kwa20ya3VtODdseDltcQ==",
+            "index": true
+          },
+          {
+            "key": "YW1vdW50",
+            "value": "NDg1NzQwNDAwMWJhc2V0Y3Jv",
+            "index": true
+          }
+        ]
+      },
+      {
+        "type": "coin_spent",
+        "attributes": [
+          {
+            "key": "c3BlbmRlcg==",
+            "value": "dGNybzFtM2gzMHdsdnNmOGxscnV4dHB1a2R2c3kwa20ya3VtODdseDltcQ==",
+            "index": true
+          },
+          {
+            "key": "YW1vdW50",
+            "value": "NDg1NzQwNDAwMWJhc2V0Y3Jv",
+            "index": true
+          }
+        ]
+      },
+      {
+        "type": "coin_received",
+        "attributes": [
+          {
+            "key": "cmVjZWl2ZXI=",
+            "value": "dGNybzE3eHBmdmFrbTJhbWc5NjJ5bHM2Zjg0ejNrZWxsOGM1bHhoemFoYQ==",
+            "index": true
+          },
+          {
+            "key": "YW1vdW50",
+            "value": "NDg1NzQwNDAwMWJhc2V0Y3Jv",
+            "index": true
+          }
+        ]
+      },
+      {
+        "type": "transfer",
+        "attributes": [
+          {
+            "key": "cmVjaXBpZW50",
+            "value": "dGNybzE3eHBmdmFrbTJhbWc5NjJ5bHM2Zjg0ejNrZWxsOGM1bHhoemFoYQ==",
+            "index": true
+          },
+          {
+            "key": "c2VuZGVy",
+            "value": "dGNybzFtM2gzMHdsdnNmOGxscnV4dHB1a2R2c3kwa20ya3VtODdseDltcQ==",
+            "index": true
+          },
+          {
+            "key": "YW1vdW50",
+            "value": "NDg1NzQwNDAwMWJhc2V0Y3Jv",
+            "index": true
+          }
+        ]
+      },
+      {
+        "type": "message",
+        "attributes": [
+          {
+            "key": "c2VuZGVy",
+            "value": "dGNybzFtM2gzMHdsdnNmOGxscnV4dHB1a2R2c3kwa20ya3VtODdseDltcQ==",
+            "index": true
+          }
+        ]
+      },
+      {
+        "type": "mint",
+        "attributes": [
+          {
+            "key": "Ym9uZGVkX3JhdGlv",
+            "value": "MC4wMDA1OTUwNDU1NDA5MjIxODA=",
+            "index": true
+          },
+          {
+            "key": "aW5mbGF0aW9u",
+            "value": "MC4wMTIxNjE3NTU0MzI0MjMxMDk=",
+            "index": true
+          },
+          {
+            "key": "YW5udWFsX3Byb3Zpc2lvbnM=",
+            "value": "MzA2NTc2MDI1MDIyMTEwMDUuOTExMjkyMDM0OTcyNTI5MTYz",
+            "index": true
+          },
+          {
+            "key": "YW1vdW50",
+            "value": "NDg1NzQwNDAwMQ==",
+            "index": true
+          }
+        ]
+      },
+      {
+        "type": "coin_spent",
+        "attributes": [
+          {
+            "key": "c3BlbmRlcg==",
+            "value": "dGNybzE3eHBmdmFrbTJhbWc5NjJ5bHM2Zjg0ejNrZWxsOGM1bHhoemFoYQ==",
+            "index": true
+          },
+          {
+            "key": "YW1vdW50",
+            "value": "NDg1NzQwNDAwMWJhc2V0Y3Jv",
+            "index": true
+          }
+        ]
+      },
+      {
+        "type": "coin_received",
+        "attributes": [
+          {
+            "key": "cmVjZWl2ZXI=",
+            "value": "dGNybzFqdjY1czNncnFmNnY2amwzZHA0dDZjOXQ5cms5OWNkODMzOXA0bA==",
+            "index": true
+          },
+          {
+            "key": "YW1vdW50",
+            "value": "NDg1NzQwNDAwMWJhc2V0Y3Jv",
+            "index": true
+          }
+        ]
+      },
+      {
+        "type": "transfer",
+        "attributes": [
+          {
+            "key": "cmVjaXBpZW50",
+            "value": "dGNybzFqdjY1czNncnFmNnY2amwzZHA0dDZjOXQ5cms5OWNkODMzOXA0bA==",
+            "index": true
+          },
+          {
+            "key": "c2VuZGVy",
+            "value": "dGNybzE3eHBmdmFrbTJhbWc5NjJ5bHM2Zjg0ejNrZWxsOGM1bHhoemFoYQ==",
+            "index": true
+          },
+          {
+            "key": "YW1vdW50",
+            "value": "NDg1NzQwNDAwMWJhc2V0Y3Jv",
+            "index": true
+          }
+        ]
+      },
+      {
+        "type": "message",
+        "attributes": [
+          {
+            "key": "c2VuZGVy",
+            "value": "dGNybzE3eHBmdmFrbTJhbWc5NjJ5bHM2Zjg0ejNrZWxsOGM1bHhoemFoYQ==",
+            "index": true
+          }
+        ]
+      },
+      {
+        "type": "proposer_reward",
+        "attributes": [
+          {
+            "key": "YW1vdW50",
+            "value": "MjQyODcwMjAwLjA1MDAwMDAwMDAwMDAwMDAwMGJhc2V0Y3Jv",
+            "index": true
+          },
+          {
+            "key": "dmFsaWRhdG9y",
+            "value": "dGNyb2NuY2wxNjN0djU5eXpnZXFjYXA4bHJzYTJyNHprNTgwaDhkZHI1YTBzZGQ=",
+            "index": true
+          }
+        ]
+      },
+      {
+        "type": "commission",
+        "attributes": [
+          {
+            "key": "YW1vdW50",
+            "value": "MjQyODcwMjAuMDA1MDAwMDAwMDAwMDAwMDAwYmFzZXRjcm8=",
+            "index": true
+          },
+          {
+            "key": "dmFsaWRhdG9y",
+            "value": "dGNyb2NuY2wxNjN0djU5eXpnZXFjYXA4bHJzYTJyNHprNTgwaDhkZHI1YTBzZGQ=",
+            "index": true
+          }
+        ]
+      },
+      {
+        "type": "rewards",
+        "attributes": [
+          {
+            "key": "YW1vdW50",
+            "value": "MjQyODcwMjAwLjA1MDAwMDAwMDAwMDAwMDAwMGJhc2V0Y3Jv",
+            "index": true
+          },
+          {
+            "key": "dmFsaWRhdG9y",
+            "value": "dGNyb2NuY2wxNjN0djU5eXpnZXFjYXA4bHJzYTJyNHprNTgwaDhkZHI1YTBzZGQ=",
+            "index": true
+          }
+        ]
+      },
+      {
+        "type": "commission",
+        "attributes": [
+          {
+            "key": "YW1vdW50",
+            "value": "MTUzODE4MTAxLjQxMDE1MTAxMTEwMzU4NTcyNGJhc2V0Y3Jv",
+            "index": true
+          },
+          {
+            "key": "dmFsaWRhdG9y",
+            "value": "dGNyb2NuY2wxNjN0djU5eXpnZXFjYXA4bHJzYTJyNHprNTgwaDhkZHI1YTBzZGQ=",
+            "index": true
+          }
+        ]
+      },
+      {
+        "type": "rewards",
+        "attributes": [
+          {
+            "key": "YW1vdW50",
+            "value": "MTUzODE4MTAxNC4xMDE1MTAxMTEwMzU4NTcyNDViYXNldGNybw==",
+            "index": true
+          },
+          {
+            "key": "dmFsaWRhdG9y",
+            "value": "dGNyb2NuY2wxNjN0djU5eXpnZXFjYXA4bHJzYTJyNHprNTgwaDhkZHI1YTBzZGQ=",
+            "index": true
+          }
+        ]
+      },
+      {
+        "type": "commission",
+        "attributes": [
+          {
+            "key": "YW1vdW50",
+            "value": "MTUzODE3NzkzLjE1OTkxMDAxOTEyOTk5NDE2OWJhc2V0Y3Jv",
+            "index": true
+          },
+          {
+            "key": "dmFsaWRhdG9y",
+            "value": "dGNyb2NuY2wxNGZ6a3N6NWg3MmV0NHNzanRxcHdzbWh6NnlzazZyNG5hNXRyNjM=",
+            "index": true
+          }
+        ]
+      },
+      {
+        "type": "rewards",
+        "attributes": [
+          {
+            "key": "YW1vdW50",
+            "value": "MTUzODE3NzkzMS41OTkxMDAxOTEyOTk5NDE2ODliYXNldGNybw==",
+            "index": true
+          },
+          {
+            "key": "dmFsaWRhdG9y",
+            "value": "dGNyb2NuY2wxNGZ6a3N6NWg3MmV0NHNzanRxcHdzbWh6NnlzazZyNG5hNXRyNjM=",
+            "index": true
+          }
+        ]
+      },
+      {
+        "type": "commission",
+        "attributes": [
+          {
+            "key": "YW1vdW50",
+            "value": "MTUzODE3NDg1LjUyNDkzODk2OTMwNDk2NjcyNmJhc2V0Y3Jv",
+            "index": true
+          },
+          {
+            "key": "dmFsaWRhdG9y",
+            "value": "dGNyb2NuY2wxczRnZ3EyenV6dndnNWs4dm54Mnhmd3RkbTRjejZ3dG51cWtsN2E=",
+            "index": true
+          }
+        ]
+      },
+      {
+        "type": "rewards",
+        "attributes": [
+          {
+            "key": "YW1vdW50",
+            "value": "MTUzODE3NDg1NS4yNDkzODk2OTMwNDk2NjcyNjRiYXNldGNybw==",
+            "index": true
+          },
+          {
+            "key": "dmFsaWRhdG9y",
+            "value": "dGNyb2NuY2wxczRnZ3EyenV6dndnNWs4dm54Mnhmd3RkbTRjejZ3dG51cWtsN2E=",
+            "index": true
+          }
+        ]
+      }
+    ],
+    "end_block_events": null,
+    "validator_updates": [
+      {
+        "pub_key": {
+          "Sum": {
+            "type": "tendermint.crypto.PublicKey_Ed25519",
+            "value": {
+              "ed25519": "pqwk90+eV9yRpfmUOYfHBfc0z17gI5LHKaqSNBuNvi4="
+            }
+          }
+        },
+        "power": "500002102"
+      }
+    ],
+    "consensus_param_updates": {
+      "block": {
+        "max_bytes": "500000",
+        "max_gas": "81500000"
+      },
+      "evidence": {
+        "max_age_num_blocks": "403200",
+        "max_age_duration": "2419200000000000",
+        "max_bytes": "150000"
+      },
+      "validator": {
+        "pub_key_types": ["ed25519"]
+      }
+    }
+  }
+}
+`

--- a/usecase/parser/test/tx_msg_exec/tx_msg_exec_msg_fund_community_pool.go
+++ b/usecase/parser/test/tx_msg_exec/tx_msg_exec_msg_fund_community_pool.go
@@ -1,0 +1,589 @@
+package usecase_parser_test
+
+const TX_MSG_EXEC_MSG_FUND_COMMUNITY_POOL_BLOCK_RESP = `
+{
+    "jsonrpc": "2.0",
+    "id": -1,
+    "result": {
+        "block_id": {
+            "hash": "2D88B3626C86523D66F996D65B0A3D359FD76D92FE8B195CDB23C475C0A24545",
+            "parts": {
+                "total": 1,
+                "hash": "8EEB7C542644BFF56D4D0AE467263CD1F8B2F4525447E6C99171D858189C10BF"
+            }
+        },
+        "block": {
+            "header": {
+                "version": {
+                    "block": "11"
+                },
+                "chain_id": "chaintest",
+                "height": "2569",
+                "time": "2022-08-11T03:19:16.711807Z",
+                "last_block_id": {
+                    "hash": "CD94C4AFCEC7AEBF541C4FBDD1E1284EDAE48BD0EB5FD20A56C59BE7AF3D0E54",
+                    "parts": {
+                        "total": 1,
+                        "hash": "5AB048BA65819A9975D88D84F748C676558081BF779866A78FE420E429E94156"
+                    }
+                },
+                "last_commit_hash": "D231D335C0503C3BE39205E4B57FE215B5599A44AC4CDC58F3923AE8A7BB650E",
+                "data_hash": "F6B6983E098BDA5F2496CD189B6C87388D6036EBD0C99657870F88F8A24C0250",
+                "validators_hash": "5EBA69EC505C58FDBA6E1C1FD3201B7A7C2822BA9403BAEBA9754D105027ECEB",
+                "next_validators_hash": "5EBA69EC505C58FDBA6E1C1FD3201B7A7C2822BA9403BAEBA9754D105027ECEB",
+                "consensus_hash": "048091BC7DDC283F77BFBF91D73C44DA58C3DF8A9CBC867405D8B7F3DAADA22F",
+                "app_hash": "4C1C45A75B81B5456974E1193D891F5B8982C86E11F0FB7D859E05BD4C2B58D6",
+                "last_results_hash": "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
+                "evidence_hash": "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
+                "proposer_address": "687E731503E488DFC9B1961EC6513CF4DEFCE59D"
+            },
+            "data": {
+                "txs": [
+                    "CrUCCrICCh0vY29zbW9zLmF1dGh6LnYxYmV0YTEuTXNnRXhlYxKQAgoqY3JvMTQwNnkwMDluNDNhd2EwZTVuNnQydDA2YTh0dHk5YXpwdTlhdDI1EnAKMS9jb3Ntb3MuZGlzdHJpYnV0aW9uLnYxYmV0YTEuTXNnRnVuZENvbW11bml0eVBvb2wSOwoNCgdiYXNlY3JvEgIxMBIqY3JvMWh0cXN4Zmo0azloaGFndHZsbXF4Nmw0ajU5M3B6ZGs3ZGR2NTBuEnAKMS9jb3Ntb3MuZGlzdHJpYnV0aW9uLnYxYmV0YTEuTXNnRnVuZENvbW11bml0eVBvb2wSOwoNCgdiYXNlY3JvEgIxMRIqY3JvMWh0cXN4Zmo0azloaGFndHZsbXF4Nmw0ajU5M3B6ZGs3ZGR2NTBuElgKUApGCh8vY29zbW9zLmNyeXB0by5zZWNwMjU2azEuUHViS2V5EiMKIQNrfGTd70aQIuyCXaBOVHUNvHddYe0krKAWqPLnwNefrhIECgIIARgGEgQQwJoMGkBbD+Ja40o6nNEy5v+3cixYPWIJRbILlhmY7gRKKIb7OCtZQj+xUciNUvhqz884gVhPu2E8fKdh9y4uA71aHsSo"
+                ]
+            },
+            "evidence": {
+                "evidence": []
+            },
+            "last_commit": {
+                "height": "2568",
+                "round": 0,
+                "block_id": {
+                    "hash": "CD94C4AFCEC7AEBF541C4FBDD1E1284EDAE48BD0EB5FD20A56C59BE7AF3D0E54",
+                    "parts": {
+                        "total": 1,
+                        "hash": "5AB048BA65819A9975D88D84F748C676558081BF779866A78FE420E429E94156"
+                    }
+                },
+                "signatures": [
+                    {
+                        "block_id_flag": 2,
+                        "validator_address": "687E731503E488DFC9B1961EC6513CF4DEFCE59D",
+                        "timestamp": "2022-08-11T03:19:16.747971Z",
+                        "signature": "a5JoLOv8/dx9SW4FmUA2SyQv5S1pBtlehaeLiXyBnr4Z80tBLNcO1J2HXX1slLS9j3jqpq3IfpaJ4CBK43xkAQ=="
+                    },
+                    {
+                        "block_id_flag": 2,
+                        "validator_address": "E37CFA47E8186366465AFD992B916502781D0919",
+                        "timestamp": "2022-08-11T03:19:16.711807Z",
+                        "signature": "ZvkJ8em2Ytu2SWvS+W3IHX7jzrtKL/hEI/72OSxPOsAiSd/77oejamJKG8Bgv0uzBAuU+dt/tB1HrzyOnK9cDA=="
+                    }
+                ]
+            }
+        }
+    }
+}
+`
+
+const TX_MSG_EXEC_MSG_FUND_COMMUNITY_POOL_BLOCK_RESULTS_RESP = `
+{
+    "jsonrpc": "2.0",
+    "id": -1,
+    "result": {
+        "height": "2569",
+        "txs_results": [
+            {
+                "code": 0,
+                "data": "CiUKHS9jb3Ntb3MuYXV0aHoudjFiZXRhMS5Nc2dFeGVjEgQKAAoA",
+                "log": "[{\"events\":[{\"type\":\"coin_received\",\"attributes\":[{\"key\":\"receiver\",\"value\":\"cro1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8lyv94w\"},{\"key\":\"amount\",\"value\":\"10basecro\"},{\"key\":\"receiver\",\"value\":\"cro1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8lyv94w\"},{\"key\":\"amount\",\"value\":\"11basecro\"}]},{\"type\":\"coin_spent\",\"attributes\":[{\"key\":\"spender\",\"value\":\"cro1htqsxfj4k9hhagtvlmqx6l4j593pzdk7ddv50n\"},{\"key\":\"amount\",\"value\":\"10basecro\"},{\"key\":\"spender\",\"value\":\"cro1htqsxfj4k9hhagtvlmqx6l4j593pzdk7ddv50n\"},{\"key\":\"amount\",\"value\":\"11basecro\"}]},{\"type\":\"message\",\"attributes\":[{\"key\":\"action\",\"value\":\"/cosmos.authz.v1beta1.MsgExec\"},{\"key\":\"sender\",\"value\":\"cro1htqsxfj4k9hhagtvlmqx6l4j593pzdk7ddv50n\"},{\"key\":\"module\",\"value\":\"distribution\"},{\"key\":\"sender\",\"value\":\"cro1htqsxfj4k9hhagtvlmqx6l4j593pzdk7ddv50n\"},{\"key\":\"sender\",\"value\":\"cro1htqsxfj4k9hhagtvlmqx6l4j593pzdk7ddv50n\"},{\"key\":\"module\",\"value\":\"distribution\"},{\"key\":\"sender\",\"value\":\"cro1htqsxfj4k9hhagtvlmqx6l4j593pzdk7ddv50n\"}]},{\"type\":\"transfer\",\"attributes\":[{\"key\":\"recipient\",\"value\":\"cro1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8lyv94w\"},{\"key\":\"sender\",\"value\":\"cro1htqsxfj4k9hhagtvlmqx6l4j593pzdk7ddv50n\"},{\"key\":\"amount\",\"value\":\"10basecro\"},{\"key\":\"recipient\",\"value\":\"cro1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8lyv94w\"},{\"key\":\"sender\",\"value\":\"cro1htqsxfj4k9hhagtvlmqx6l4j593pzdk7ddv50n\"},{\"key\":\"amount\",\"value\":\"11basecro\"}]}]}]",
+                "info": "",
+                "gas_wanted": "200000",
+                "gas_used": "79803",
+                "events": [
+                    {
+                        "type": "tx",
+                        "attributes": [
+                            {
+                                "key": "ZmVl",
+                                "value": null,
+                                "index": true
+                            }
+                        ]
+                    },
+                    {
+                        "type": "tx",
+                        "attributes": [
+                            {
+                                "key": "YWNjX3NlcQ==",
+                                "value": "Y3JvMTQwNnkwMDluNDNhd2EwZTVuNnQydDA2YTh0dHk5YXpwdTlhdDI1LzY=",
+                                "index": true
+                            }
+                        ]
+                    },
+                    {
+                        "type": "tx",
+                        "attributes": [
+                            {
+                                "key": "c2lnbmF0dXJl",
+                                "value": "V3cvaVd1TktPcHpSTXViL3QzSXNXRDFpQ1VXeUM1WVptTzRFU2lpRyt6Z3JXVUkvc1ZISWpWTDRhcy9QT0lGWVQ3dGhQSHluWWZjdUxnTzlXaDdFcUE9PQ==",
+                                "index": true
+                            }
+                        ]
+                    },
+                    {
+                        "type": "message",
+                        "attributes": [
+                            {
+                                "key": "YWN0aW9u",
+                                "value": "L2Nvc21vcy5hdXRoei52MWJldGExLk1zZ0V4ZWM=",
+                                "index": true
+                            }
+                        ]
+                    },
+                    {
+                        "type": "coin_spent",
+                        "attributes": [
+                            {
+                                "key": "c3BlbmRlcg==",
+                                "value": "Y3JvMWh0cXN4Zmo0azloaGFndHZsbXF4Nmw0ajU5M3B6ZGs3ZGR2NTBu",
+                                "index": true
+                            },
+                            {
+                                "key": "YW1vdW50",
+                                "value": "MTBiYXNlY3Jv",
+                                "index": true
+                            }
+                        ]
+                    },
+                    {
+                        "type": "coin_received",
+                        "attributes": [
+                            {
+                                "key": "cmVjZWl2ZXI=",
+                                "value": "Y3JvMWp2NjVzM2dycWY2djZqbDNkcDR0NmM5dDlyazk5Y2Q4bHl2OTR3",
+                                "index": true
+                            },
+                            {
+                                "key": "YW1vdW50",
+                                "value": "MTBiYXNlY3Jv",
+                                "index": true
+                            }
+                        ]
+                    },
+                    {
+                        "type": "transfer",
+                        "attributes": [
+                            {
+                                "key": "cmVjaXBpZW50",
+                                "value": "Y3JvMWp2NjVzM2dycWY2djZqbDNkcDR0NmM5dDlyazk5Y2Q4bHl2OTR3",
+                                "index": true
+                            },
+                            {
+                                "key": "c2VuZGVy",
+                                "value": "Y3JvMWh0cXN4Zmo0azloaGFndHZsbXF4Nmw0ajU5M3B6ZGs3ZGR2NTBu",
+                                "index": true
+                            },
+                            {
+                                "key": "YW1vdW50",
+                                "value": "MTBiYXNlY3Jv",
+                                "index": true
+                            }
+                        ]
+                    },
+                    {
+                        "type": "message",
+                        "attributes": [
+                            {
+                                "key": "c2VuZGVy",
+                                "value": "Y3JvMWh0cXN4Zmo0azloaGFndHZsbXF4Nmw0ajU5M3B6ZGs3ZGR2NTBu",
+                                "index": true
+                            }
+                        ]
+                    },
+                    {
+                        "type": "message",
+                        "attributes": [
+                            {
+                                "key": "bW9kdWxl",
+                                "value": "ZGlzdHJpYnV0aW9u",
+                                "index": true
+                            },
+                            {
+                                "key": "c2VuZGVy",
+                                "value": "Y3JvMWh0cXN4Zmo0azloaGFndHZsbXF4Nmw0ajU5M3B6ZGs3ZGR2NTBu",
+                                "index": true
+                            }
+                        ]
+                    },
+                    {
+                        "type": "coin_spent",
+                        "attributes": [
+                            {
+                                "key": "c3BlbmRlcg==",
+                                "value": "Y3JvMWh0cXN4Zmo0azloaGFndHZsbXF4Nmw0ajU5M3B6ZGs3ZGR2NTBu",
+                                "index": true
+                            },
+                            {
+                                "key": "YW1vdW50",
+                                "value": "MTFiYXNlY3Jv",
+                                "index": true
+                            }
+                        ]
+                    },
+                    {
+                        "type": "coin_received",
+                        "attributes": [
+                            {
+                                "key": "cmVjZWl2ZXI=",
+                                "value": "Y3JvMWp2NjVzM2dycWY2djZqbDNkcDR0NmM5dDlyazk5Y2Q4bHl2OTR3",
+                                "index": true
+                            },
+                            {
+                                "key": "YW1vdW50",
+                                "value": "MTFiYXNlY3Jv",
+                                "index": true
+                            }
+                        ]
+                    },
+                    {
+                        "type": "transfer",
+                        "attributes": [
+                            {
+                                "key": "cmVjaXBpZW50",
+                                "value": "Y3JvMWp2NjVzM2dycWY2djZqbDNkcDR0NmM5dDlyazk5Y2Q4bHl2OTR3",
+                                "index": true
+                            },
+                            {
+                                "key": "c2VuZGVy",
+                                "value": "Y3JvMWh0cXN4Zmo0azloaGFndHZsbXF4Nmw0ajU5M3B6ZGs3ZGR2NTBu",
+                                "index": true
+                            },
+                            {
+                                "key": "YW1vdW50",
+                                "value": "MTFiYXNlY3Jv",
+                                "index": true
+                            }
+                        ]
+                    },
+                    {
+                        "type": "message",
+                        "attributes": [
+                            {
+                                "key": "c2VuZGVy",
+                                "value": "Y3JvMWh0cXN4Zmo0azloaGFndHZsbXF4Nmw0ajU5M3B6ZGs3ZGR2NTBu",
+                                "index": true
+                            }
+                        ]
+                    },
+                    {
+                        "type": "message",
+                        "attributes": [
+                            {
+                                "key": "bW9kdWxl",
+                                "value": "ZGlzdHJpYnV0aW9u",
+                                "index": true
+                            },
+                            {
+                                "key": "c2VuZGVy",
+                                "value": "Y3JvMWh0cXN4Zmo0azloaGFndHZsbXF4Nmw0ajU5M3B6ZGs3ZGR2NTBu",
+                                "index": true
+                            }
+                        ]
+                    }
+                ],
+                "codespace": ""
+            }
+        ],
+        "begin_block_events": [
+            {
+                "type": "coin_received",
+                "attributes": [
+                    {
+                        "key": "cmVjZWl2ZXI=",
+                        "value": "Y3JvMW0zaDMwd2x2c2Y4bGxydXh0cHVrZHZzeTBrbTJrdW04czIwcG0z",
+                        "index": true
+                    },
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MzQyNDhiYXNlY3Jv",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "coinbase",
+                "attributes": [
+                    {
+                        "key": "bWludGVy",
+                        "value": "Y3JvMW0zaDMwd2x2c2Y4bGxydXh0cHVrZHZzeTBrbTJrdW04czIwcG0z",
+                        "index": true
+                    },
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MzQyNDhiYXNlY3Jv",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "coin_spent",
+                "attributes": [
+                    {
+                        "key": "c3BlbmRlcg==",
+                        "value": "Y3JvMW0zaDMwd2x2c2Y4bGxydXh0cHVrZHZzeTBrbTJrdW04czIwcG0z",
+                        "index": true
+                    },
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MzQyNDhiYXNlY3Jv",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "coin_received",
+                "attributes": [
+                    {
+                        "key": "cmVjZWl2ZXI=",
+                        "value": "Y3JvMTd4cGZ2YWttMmFtZzk2MnlsczZmODR6M2tlbGw4YzVsZ3p0ZWh2",
+                        "index": true
+                    },
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MzQyNDhiYXNlY3Jv",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "transfer",
+                "attributes": [
+                    {
+                        "key": "cmVjaXBpZW50",
+                        "value": "Y3JvMTd4cGZ2YWttMmFtZzk2MnlsczZmODR6M2tlbGw4YzVsZ3p0ZWh2",
+                        "index": true
+                    },
+                    {
+                        "key": "c2VuZGVy",
+                        "value": "Y3JvMW0zaDMwd2x2c2Y4bGxydXh0cHVrZHZzeTBrbTJrdW04czIwcG0z",
+                        "index": true
+                    },
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MzQyNDhiYXNlY3Jv",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "message",
+                "attributes": [
+                    {
+                        "key": "c2VuZGVy",
+                        "value": "Y3JvMW0zaDMwd2x2c2Y4bGxydXh0cHVrZHZzeTBrbTJrdW04czIwcG0z",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "mint",
+                "attributes": [
+                    {
+                        "key": "Ym9uZGVkX3JhdGlv",
+                        "value": "MC4wMDEyMDMzMDU3NzM5NzE4NjQ=",
+                        "index": true
+                    },
+                    {
+                        "key": "aW5mbGF0aW9u",
+                        "value": "MC4xMzAwNTI4MTkzMTc4NjY5OTE=",
+                        "index": true
+                    },
+                    {
+                        "key": "YW5udWFsX3Byb3Zpc2lvbnM=",
+                        "value": "MjE2MTU5MjIxMDMyLjU5ODk4MTA5MDQ1NTY4NjA5Mw==",
+                        "index": true
+                    },
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MzQyNDg=",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "coin_spent",
+                "attributes": [
+                    {
+                        "key": "c3BlbmRlcg==",
+                        "value": "Y3JvMTd4cGZ2YWttMmFtZzk2MnlsczZmODR6M2tlbGw4YzVsZ3p0ZWh2",
+                        "index": true
+                    },
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MzQyNDhiYXNlY3Jv",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "coin_received",
+                "attributes": [
+                    {
+                        "key": "cmVjZWl2ZXI=",
+                        "value": "Y3JvMWp2NjVzM2dycWY2djZqbDNkcDR0NmM5dDlyazk5Y2Q4bHl2OTR3",
+                        "index": true
+                    },
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MzQyNDhiYXNlY3Jv",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "transfer",
+                "attributes": [
+                    {
+                        "key": "cmVjaXBpZW50",
+                        "value": "Y3JvMWp2NjVzM2dycWY2djZqbDNkcDR0NmM5dDlyazk5Y2Q4bHl2OTR3",
+                        "index": true
+                    },
+                    {
+                        "key": "c2VuZGVy",
+                        "value": "Y3JvMTd4cGZ2YWttMmFtZzk2MnlsczZmODR6M2tlbGw4YzVsZ3p0ZWh2",
+                        "index": true
+                    },
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MzQyNDhiYXNlY3Jv",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "message",
+                "attributes": [
+                    {
+                        "key": "c2VuZGVy",
+                        "value": "Y3JvMTd4cGZ2YWttMmFtZzk2MnlsczZmODR6M2tlbGw4YzVsZ3p0ZWh2",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "proposer_reward",
+                "attributes": [
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MTcxMi40MDAwMDAwMDAwMDAwMDAwMDBiYXNlY3Jv",
+                        "index": true
+                    },
+                    {
+                        "key": "dmFsaWRhdG9y",
+                        "value": "Y3JvY25jbDFodHFzeGZqNGs5aGhhZ3R2bG1xeDZsNGo1OTNwemRrN3dxMGFkMA==",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "commission",
+                "attributes": [
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MTcxLjI0MDAwMDAwMDAwMDAwMDAwMGJhc2Vjcm8=",
+                        "index": true
+                    },
+                    {
+                        "key": "dmFsaWRhdG9y",
+                        "value": "Y3JvY25jbDFodHFzeGZqNGs5aGhhZ3R2bG1xeDZsNGo1OTNwemRrN3dxMGFkMA==",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "rewards",
+                "attributes": [
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MTcxMi40MDAwMDAwMDAwMDAwMDAwMDBiYXNlY3Jv",
+                        "index": true
+                    },
+                    {
+                        "key": "dmFsaWRhdG9y",
+                        "value": "Y3JvY25jbDFodHFzeGZqNGs5aGhhZ3R2bG1xeDZsNGo1OTNwemRrN3dxMGFkMA==",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "commission",
+                "attributes": [
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MTU5Mi41MzIwMDAwMDAwMDAwMDAwMDBiYXNlY3Jv",
+                        "index": true
+                    },
+                    {
+                        "key": "dmFsaWRhdG9y",
+                        "value": "Y3JvY25jbDE3Y3llNWdtZWFsbXBnejN0Y2xmamdhN3VyZGp4ajZuYWgzdTh3Mg==",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "rewards",
+                "attributes": [
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MTU5MjUuMzIwMDAwMDAwMDAwMDAwMDAwYmFzZWNybw==",
+                        "index": true
+                    },
+                    {
+                        "key": "dmFsaWRhdG9y",
+                        "value": "Y3JvY25jbDE3Y3llNWdtZWFsbXBnejN0Y2xmamdhN3VyZGp4ajZuYWgzdTh3Mg==",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "commission",
+                "attributes": [
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MTU5Mi41MzIwMDAwMDAwMDAwMDAwMDBiYXNlY3Jv",
+                        "index": true
+                    },
+                    {
+                        "key": "dmFsaWRhdG9y",
+                        "value": "Y3JvY25jbDFodHFzeGZqNGs5aGhhZ3R2bG1xeDZsNGo1OTNwemRrN3dxMGFkMA==",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "rewards",
+                "attributes": [
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MTU5MjUuMzIwMDAwMDAwMDAwMDAwMDAwYmFzZWNybw==",
+                        "index": true
+                    },
+                    {
+                        "key": "dmFsaWRhdG9y",
+                        "value": "Y3JvY25jbDFodHFzeGZqNGs5aGhhZ3R2bG1xeDZsNGo1OTNwemRrN3dxMGFkMA==",
+                        "index": true
+                    }
+                ]
+            }
+        ],
+        "end_block_events": null,
+        "validator_updates": null,
+        "consensus_param_updates": {
+            "block": {
+                "max_bytes": "22020096",
+                "max_gas": "-1"
+            },
+            "evidence": {
+                "max_age_num_blocks": "100000",
+                "max_age_duration": "172800000000000",
+                "max_bytes": "1048576"
+            },
+            "validator": {
+                "pub_key_types": [
+                    "ed25519"
+                ]
+            }
+        }
+    }
+}
+`

--- a/usecase/parser/test/tx_msg_exec/tx_msg_exec_msg_send.go
+++ b/usecase/parser/test/tx_msg_exec/tx_msg_exec_msg_send.go
@@ -1,0 +1,593 @@
+package usecase_parser_test
+
+const TX_MSG_EXEC_MSG_SEND_BLOCK_RESP = `{
+  "jsonrpc": "2.0",
+  "id": -1,
+  "result": {
+    "block_id": {
+      "hash": "4BA2468ADCA23EAAD3CC2818C123173B44FE6CDC0FAD4D3A0799B0A47E8386E3",
+      "parts": {
+        "total": 1,
+        "hash": "B4D103EB478FD8C566E2ACF6E88072FB0C1F77C3658B01926B8443BA0195A25A"
+      }
+    },
+    "block": {
+      "header": {
+        "version": {
+          "block": "11"
+        },
+        "chain_id": "testnet-croeseid-4",
+        "height": "113382",
+        "time": "2021-08-26T04:56:23.854458166Z",
+        "last_block_id": {
+          "hash": "B60748462F8F3E14808979E698B4F2D062E02A90E330A36D3265FBB1B882AFF6",
+          "parts": {
+            "total": 1,
+            "hash": "B3D5B588FF679FA6A37059327A19899A19D7A23B799A6CB7EA4BA304E842072F"
+          }
+        },
+        "last_commit_hash": "F056E5D486FC2D5C9D9CB2774E19B59864A259F673C5E83B6FF8806CA482921F",
+        "data_hash": "3ABD2ABA5F7D8A324600DEA2EBB9342971961CB8C14D05D9C7FEDB61A6D8A8E6",
+        "validators_hash": "77B520746A7915359B36FBB0FC761C77528FCB68E5998412B6CCDA1CF6B30FC9",
+        "next_validators_hash": "77B520746A7915359B36FBB0FC761C77528FCB68E5998412B6CCDA1CF6B30FC9",
+        "consensus_hash": "372B4AE845086C837EFEF79A189B085B1FD6610C53F3BEB17EE0E27B347C06DE",
+        "app_hash": "3A1900BB913898F91CFC5940C982591F461D062E8188199D7D8E7FC3E43F582E",
+        "last_results_hash": "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
+        "evidence_hash": "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
+        "proposer_address": "71DA178AE52B2D0654102A86166CE91AC5121CB2"
+      },
+      "data": {
+        "txs": [
+          "CuYBCuMBCh0vY29zbW9zLmF1dGh6LnYxYmV0YTEuTXNnRXhlYxLBAQordGNybzE1emg1dG43eGpkZWN1NHpqY2xzbWxubGh0NWVhZDJteDg0Z2F1MhKRAQocL2Nvc21vcy5iYW5rLnYxYmV0YTEuTXNnU2VuZBJxCit0Y3JvMXZ1cmZocWYwajJqZ2ZwamFobGphNmc2dXEydHMycjYwc3dtMmQ5Eit0Y3JvMWE5M3lmbnNjM3g3bTBtNDQ1Y2pzdmVlMm43cXo5YzBwdXJsendxGhUKCGJhc2V0Y3JvEgkxMDAwMDAwMDASawpQCkYKHy9jb3Ntb3MuY3J5cHRvLnNlY3AyNTZrMS5QdWJLZXkSIwohA/ZmZrKTHzpFHfml++KJ3lO8qQysug3ls0/McPi6TY3oEgQKAggBGAMSFwoRCghiYXNldGNybxIFNTAwMDAQwJoMGkDUsthteS7lTq+Ldp1JriOoban1HEpio4TGcsDv1dcyei7iVxo2EGiLewWFVZ8RqgNM4SwukAoNmNca55eijx0z"
+        ]
+      },
+      "evidence": {
+        "evidence": []
+      },
+      "last_commit": {
+        "height": "113381",
+        "round": 0,
+        "block_id": {
+          "hash": "B60748462F8F3E14808979E698B4F2D062E02A90E330A36D3265FBB1B882AFF6",
+          "parts": {
+            "total": 1,
+            "hash": "B3D5B588FF679FA6A37059327A19899A19D7A23B799A6CB7EA4BA304E842072F"
+          }
+        },
+        "signatures": [
+          {
+            "block_id_flag": 2,
+            "validator_address": "F9A4582896E5F2692BEDDD7C251755E33D2DE013",
+            "timestamp": "2021-08-26T04:56:23.910207522Z",
+            "signature": "LIGswOX+KFHB1wO/kuJDpNuk/DzwsX20U12gvOiAQ4HSl6F5zd1VlvxcNnyVxqQ5whBum38vQ0w4BP2hp8HVAQ=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "71DA178AE52B2D0654102A86166CE91AC5121CB2",
+            "timestamp": "2021-08-26T04:56:23.854458166Z",
+            "signature": "SrwtVL3ZX39u2Yb04plPhdsBb3M67bVggAOwrkji9NvJEAs8bGXoJhNEjjZFzRFxOcuJGtV1FQBDiGuvKqI/Aw=="
+          },
+          {
+            "block_id_flag": 2,
+            "validator_address": "7E2B455523A35AE8F4064C00AF01515FEF673079",
+            "timestamp": "2021-08-26T04:56:23.825722636Z",
+            "signature": "OQEnrSTYgCWzkBb9SaZiTbEY1isS4AEdBkctN63nazbC/ynjBT8A8cLmRLaN5yc+1QesGVyZSZft5KaDabpwCQ=="
+          }
+        ]
+      }
+    }
+  }
+}`
+
+const TX_MSG_EXEC_MSG_SEND_BLOCK_RESULTS_RESP = `
+{
+  "jsonrpc": "2.0",
+  "id": -1,
+  "result": {
+    "height": "113382",
+    "txs_results": [
+      {
+        "code": 0,
+        "data": "CiMKHS9jb3Ntb3MuYXV0aHoudjFiZXRhMS5Nc2dFeGVjEgIKAA==",
+        "log": "[{\"events\":[{\"type\":\"coin_received\",\"attributes\":[{\"key\":\"receiver\",\"value\":\"tcro1a93yfnsc3x7m0m445cjsvee2n7qz9c0purlzwq\"},{\"key\":\"amount\",\"value\":\"100000000basetcro\"}]},{\"type\":\"coin_spent\",\"attributes\":[{\"key\":\"spender\",\"value\":\"tcro1vurfhqf0j2jgfpjahlja6g6uq2ts2r60swm2d9\"},{\"key\":\"amount\",\"value\":\"100000000basetcro\"}]},{\"type\":\"message\",\"attributes\":[{\"key\":\"action\",\"value\":\"/cosmos.authz.v1beta1.MsgExec\"},{\"key\":\"sender\",\"value\":\"tcro1vurfhqf0j2jgfpjahlja6g6uq2ts2r60swm2d9\"},{\"key\":\"module\",\"value\":\"bank\"}]},{\"type\":\"transfer\",\"attributes\":[{\"key\":\"recipient\",\"value\":\"tcro1a93yfnsc3x7m0m445cjsvee2n7qz9c0purlzwq\"},{\"key\":\"sender\",\"value\":\"tcro1vurfhqf0j2jgfpjahlja6g6uq2ts2r60swm2d9\"},{\"key\":\"amount\",\"value\":\"100000000basetcro\"}]}]}]",
+        "info": "",
+        "gas_wanted": "200000",
+        "gas_used": "76874",
+        "events": [
+          {
+            "type": "coin_spent",
+            "attributes": [
+              {
+                "key": "c3BlbmRlcg==",
+                "value": "dGNybzE1emg1dG43eGpkZWN1NHpqY2xzbWxubGh0NWVhZDJteDg0Z2F1Mg==",
+                "index": true
+              },
+              {
+                "key": "YW1vdW50",
+                "value": "NTAwMDBiYXNldGNybw==",
+                "index": true
+              }
+            ]
+          },
+          {
+            "type": "coin_received",
+            "attributes": [
+              {
+                "key": "cmVjZWl2ZXI=",
+                "value": "dGNybzE3eHBmdmFrbTJhbWc5NjJ5bHM2Zjg0ejNrZWxsOGM1bHhoemFoYQ==",
+                "index": true
+              },
+              {
+                "key": "YW1vdW50",
+                "value": "NTAwMDBiYXNldGNybw==",
+                "index": true
+              }
+            ]
+          },
+          {
+            "type": "transfer",
+            "attributes": [
+              {
+                "key": "cmVjaXBpZW50",
+                "value": "dGNybzE3eHBmdmFrbTJhbWc5NjJ5bHM2Zjg0ejNrZWxsOGM1bHhoemFoYQ==",
+                "index": true
+              },
+              {
+                "key": "c2VuZGVy",
+                "value": "dGNybzE1emg1dG43eGpkZWN1NHpqY2xzbWxubGh0NWVhZDJteDg0Z2F1Mg==",
+                "index": true
+              },
+              {
+                "key": "YW1vdW50",
+                "value": "NTAwMDBiYXNldGNybw==",
+                "index": true
+              }
+            ]
+          },
+          {
+            "type": "message",
+            "attributes": [
+              {
+                "key": "c2VuZGVy",
+                "value": "dGNybzE1emg1dG43eGpkZWN1NHpqY2xzbWxubGh0NWVhZDJteDg0Z2F1Mg==",
+                "index": true
+              }
+            ]
+          },
+          {
+            "type": "tx",
+            "attributes": [
+              {
+                "key": "YWNjX3NlcQ==",
+                "value": "dGNybzE1emg1dG43eGpkZWN1NHpqY2xzbWxubGh0NWVhZDJteDg0Z2F1Mi8z",
+                "index": true
+              }
+            ]
+          },
+          {
+            "type": "tx",
+            "attributes": [
+              {
+                "key": "c2lnbmF0dXJl",
+                "value": "MUxMWWJYa3U1VTZ2aTNhZFNhNGpxRzJwOVJ4S1lxT0V4bkxBNzlYWE1ub3U0bGNhTmhCb2kzc0ZoVldmRWFvRFRPRXNMcEFLRFpqWEd1ZVhvbzhkTXc9PQ==",
+                "index": true
+              }
+            ]
+          },
+          {
+            "type": "message",
+            "attributes": [
+              {
+                "key": "YWN0aW9u",
+                "value": "L2Nvc21vcy5hdXRoei52MWJldGExLk1zZ0V4ZWM=",
+                "index": true
+              }
+            ]
+          },
+          {
+            "type": "coin_spent",
+            "attributes": [
+              {
+                "key": "c3BlbmRlcg==",
+                "value": "dGNybzF2dXJmaHFmMGoyamdmcGphaGxqYTZnNnVxMnRzMnI2MHN3bTJkOQ==",
+                "index": true
+              },
+              {
+                "key": "YW1vdW50",
+                "value": "MTAwMDAwMDAwYmFzZXRjcm8=",
+                "index": true
+              }
+            ]
+          },
+          {
+            "type": "coin_received",
+            "attributes": [
+              {
+                "key": "cmVjZWl2ZXI=",
+                "value": "dGNybzFhOTN5Zm5zYzN4N20wbTQ0NWNqc3ZlZTJuN3F6OWMwcHVybHp3cQ==",
+                "index": true
+              },
+              {
+                "key": "YW1vdW50",
+                "value": "MTAwMDAwMDAwYmFzZXRjcm8=",
+                "index": true
+              }
+            ]
+          },
+          {
+            "type": "transfer",
+            "attributes": [
+              {
+                "key": "cmVjaXBpZW50",
+                "value": "dGNybzFhOTN5Zm5zYzN4N20wbTQ0NWNqc3ZlZTJuN3F6OWMwcHVybHp3cQ==",
+                "index": true
+              },
+              {
+                "key": "c2VuZGVy",
+                "value": "dGNybzF2dXJmaHFmMGoyamdmcGphaGxqYTZnNnVxMnRzMnI2MHN3bTJkOQ==",
+                "index": true
+              },
+              {
+                "key": "YW1vdW50",
+                "value": "MTAwMDAwMDAwYmFzZXRjcm8=",
+                "index": true
+              }
+            ]
+          },
+          {
+            "type": "message",
+            "attributes": [
+              {
+                "key": "c2VuZGVy",
+                "value": "dGNybzF2dXJmaHFmMGoyamdmcGphaGxqYTZnNnVxMnRzMnI2MHN3bTJkOQ==",
+                "index": true
+              }
+            ]
+          },
+          {
+            "type": "message",
+            "attributes": [
+              {
+                "key": "bW9kdWxl",
+                "value": "YmFuaw==",
+                "index": true
+              }
+            ]
+          }
+        ],
+        "codespace": ""
+      }
+    ],
+    "begin_block_events": [
+      {
+        "type": "coin_received",
+        "attributes": [
+          {
+            "key": "cmVjZWl2ZXI=",
+            "value": "dGNybzFtM2gzMHdsdnNmOGxscnV4dHB1a2R2c3kwa20ya3VtODdseDltcQ==",
+            "index": true
+          },
+          {
+            "key": "YW1vdW50",
+            "value": "NDgzNTIzNTYxOGJhc2V0Y3Jv",
+            "index": true
+          }
+        ]
+      },
+      {
+        "type": "coinbase",
+        "attributes": [
+          {
+            "key": "bWludGVy",
+            "value": "dGNybzFtM2gzMHdsdnNmOGxscnV4dHB1a2R2c3kwa20ya3VtODdseDltcQ==",
+            "index": true
+          },
+          {
+            "key": "YW1vdW50",
+            "value": "NDgzNTIzNTYxOGJhc2V0Y3Jv",
+            "index": true
+          }
+        ]
+      },
+      {
+        "type": "coin_spent",
+        "attributes": [
+          {
+            "key": "c3BlbmRlcg==",
+            "value": "dGNybzFtM2gzMHdsdnNmOGxscnV4dHB1a2R2c3kwa20ya3VtODdseDltcQ==",
+            "index": true
+          },
+          {
+            "key": "YW1vdW50",
+            "value": "NDgzNTIzNTYxOGJhc2V0Y3Jv",
+            "index": true
+          }
+        ]
+      },
+      {
+        "type": "coin_received",
+        "attributes": [
+          {
+            "key": "cmVjZWl2ZXI=",
+            "value": "dGNybzE3eHBmdmFrbTJhbWc5NjJ5bHM2Zjg0ejNrZWxsOGM1bHhoemFoYQ==",
+            "index": true
+          },
+          {
+            "key": "YW1vdW50",
+            "value": "NDgzNTIzNTYxOGJhc2V0Y3Jv",
+            "index": true
+          }
+        ]
+      },
+      {
+        "type": "transfer",
+        "attributes": [
+          {
+            "key": "cmVjaXBpZW50",
+            "value": "dGNybzE3eHBmdmFrbTJhbWc5NjJ5bHM2Zjg0ejNrZWxsOGM1bHhoemFoYQ==",
+            "index": true
+          },
+          {
+            "key": "c2VuZGVy",
+            "value": "dGNybzFtM2gzMHdsdnNmOGxscnV4dHB1a2R2c3kwa20ya3VtODdseDltcQ==",
+            "index": true
+          },
+          {
+            "key": "YW1vdW50",
+            "value": "NDgzNTIzNTYxOGJhc2V0Y3Jv",
+            "index": true
+          }
+        ]
+      },
+      {
+        "type": "message",
+        "attributes": [
+          {
+            "key": "c2VuZGVy",
+            "value": "dGNybzFtM2gzMHdsdnNmOGxscnV4dHB1a2R2c3kwa20ya3VtODdseDltcQ==",
+            "index": true
+          }
+        ]
+      },
+      {
+        "type": "mint",
+        "attributes": [
+          {
+            "key": "Ym9uZGVkX3JhdGlv",
+            "value": "MC4wMDA1OTUxMTA0MTAwMjk0NDI=",
+            "index": true
+          },
+          {
+            "key": "aW5mbGF0aW9u",
+            "value": "MC4wMTIxMDc1NzA5NzQ0NzEyMDI=",
+            "index": true
+          },
+          {
+            "key": "YW5udWFsX3Byb3Zpc2lvbnM=",
+            "value": "MzA1MTc2ODYzMTI2Nzk1NjIuODc3ODk2NzczMzAzOTk3MDQ4",
+            "index": true
+          },
+          {
+            "key": "YW1vdW50",
+            "value": "NDgzNTIzNTYxOA==",
+            "index": true
+          }
+        ]
+      },
+      {
+        "type": "coin_spent",
+        "attributes": [
+          {
+            "key": "c3BlbmRlcg==",
+            "value": "dGNybzE3eHBmdmFrbTJhbWc5NjJ5bHM2Zjg0ejNrZWxsOGM1bHhoemFoYQ==",
+            "index": true
+          },
+          {
+            "key": "YW1vdW50",
+            "value": "NDgzNTIzNTYxOGJhc2V0Y3Jv",
+            "index": true
+          }
+        ]
+      },
+      {
+        "type": "coin_received",
+        "attributes": [
+          {
+            "key": "cmVjZWl2ZXI=",
+            "value": "dGNybzFqdjY1czNncnFmNnY2amwzZHA0dDZjOXQ5cms5OWNkODMzOXA0bA==",
+            "index": true
+          },
+          {
+            "key": "YW1vdW50",
+            "value": "NDgzNTIzNTYxOGJhc2V0Y3Jv",
+            "index": true
+          }
+        ]
+      },
+      {
+        "type": "transfer",
+        "attributes": [
+          {
+            "key": "cmVjaXBpZW50",
+            "value": "dGNybzFqdjY1czNncnFmNnY2amwzZHA0dDZjOXQ5cms5OWNkODMzOXA0bA==",
+            "index": true
+          },
+          {
+            "key": "c2VuZGVy",
+            "value": "dGNybzE3eHBmdmFrbTJhbWc5NjJ5bHM2Zjg0ejNrZWxsOGM1bHhoemFoYQ==",
+            "index": true
+          },
+          {
+            "key": "YW1vdW50",
+            "value": "NDgzNTIzNTYxOGJhc2V0Y3Jv",
+            "index": true
+          }
+        ]
+      },
+      {
+        "type": "message",
+        "attributes": [
+          {
+            "key": "c2VuZGVy",
+            "value": "dGNybzE3eHBmdmFrbTJhbWc5NjJ5bHM2Zjg0ejNrZWxsOGM1bHhoemFoYQ==",
+            "index": true
+          }
+        ]
+      },
+      {
+        "type": "proposer_reward",
+        "attributes": [
+          {
+            "key": "YW1vdW50",
+            "value": "MjQxNzYxNzgwLjkwMDAwMDAwMDAwMDAwMDAwMGJhc2V0Y3Jv",
+            "index": true
+          },
+          {
+            "key": "dmFsaWRhdG9y",
+            "value": "dGNyb2NuY2wxNjN0djU5eXpnZXFjYXA4bHJzYTJyNHprNTgwaDhkZHI1YTBzZGQ=",
+            "index": true
+          }
+        ]
+      },
+      {
+        "type": "commission",
+        "attributes": [
+          {
+            "key": "YW1vdW50",
+            "value": "MjQxNzYxNzguMDkwMDAwMDAwMDAwMDAwMDAwYmFzZXRjcm8=",
+            "index": true
+          },
+          {
+            "key": "dmFsaWRhdG9y",
+            "value": "dGNyb2NuY2wxNjN0djU5eXpnZXFjYXA4bHJzYTJyNHprNTgwaDhkZHI1YTBzZGQ=",
+            "index": true
+          }
+        ]
+      },
+      {
+        "type": "rewards",
+        "attributes": [
+          {
+            "key": "YW1vdW50",
+            "value": "MjQxNzYxNzgwLjkwMDAwMDAwMDAwMDAwMDAwMGJhc2V0Y3Jv",
+            "index": true
+          },
+          {
+            "key": "dmFsaWRhdG9y",
+            "value": "dGNyb2NuY2wxNjN0djU5eXpnZXFjYXA4bHJzYTJyNHprNTgwaDhkZHI1YTBzZGQ=",
+            "index": true
+          }
+        ]
+      },
+      {
+        "type": "commission",
+        "attributes": [
+          {
+            "key": "YW1vdW50",
+            "value": "MTUzMTE2MTAxLjIwOTI4NDIzNzkyNTc0OTQyMmJhc2V0Y3Jv",
+            "index": true
+          },
+          {
+            "key": "dmFsaWRhdG9y",
+            "value": "dGNyb2NuY2wxNjN0djU5eXpnZXFjYXA4bHJzYTJyNHprNTgwaDhkZHI1YTBzZGQ=",
+            "index": true
+          }
+        ]
+      },
+      {
+        "type": "rewards",
+        "attributes": [
+          {
+            "key": "YW1vdW50",
+            "value": "MTUzMTE2MTAxMi4wOTI4NDIzNzkyNTc0OTQyMTliYXNldGNybw==",
+            "index": true
+          },
+          {
+            "key": "dmFsaWRhdG9y",
+            "value": "dGNyb2NuY2wxNjN0djU5eXpnZXFjYXA4bHJzYTJyNHprNTgwaDhkZHI1YTBzZGQ=",
+            "index": true
+          }
+        ]
+      },
+      {
+        "type": "commission",
+        "attributes": [
+          {
+            "key": "YW1vdW50",
+            "value": "MTUzMTE1Nzk0LjM2NTg0NjAxNTY1MDg2MjcxNmJhc2V0Y3Jv",
+            "index": true
+          },
+          {
+            "key": "dmFsaWRhdG9y",
+            "value": "dGNyb2NuY2wxNGZ6a3N6NWg3MmV0NHNzanRxcHdzbWh6NnlzazZyNG5hNXRyNjM=",
+            "index": true
+          }
+        ]
+      },
+      {
+        "type": "rewards",
+        "attributes": [
+          {
+            "key": "YW1vdW50",
+            "value": "MTUzMTE1Nzk0My42NTg0NjAxNTY1MDg2MjcxNjNiYXNldGNybw==",
+            "index": true
+          },
+          {
+            "key": "dmFsaWRhdG9y",
+            "value": "dGNyb2NuY2wxNGZ6a3N6NWg3MmV0NHNzanRxcHdzbWh6NnlzazZyNG5hNXRyNjM=",
+            "index": true
+          }
+        ]
+      },
+      {
+        "type": "commission",
+        "attributes": [
+          {
+            "key": "YW1vdW50",
+            "value": "MTUzMTE1NDg4LjEzNDg2OTc0NTk2NDA0MDQ3OGJhc2V0Y3Jv",
+            "index": true
+          },
+          {
+            "key": "dmFsaWRhdG9y",
+            "value": "dGNyb2NuY2wxczRnZ3EyenV6dndnNWs4dm54Mnhmd3RkbTRjejZ3dG51cWtsN2E=",
+            "index": true
+          }
+        ]
+      },
+      {
+        "type": "rewards",
+        "attributes": [
+          {
+            "key": "YW1vdW50",
+            "value": "MTUzMTE1NDg4MS4zNDg2OTc0NTk2NDA0MDQ3ODBiYXNldGNybw==",
+            "index": true
+          },
+          {
+            "key": "dmFsaWRhdG9y",
+            "value": "dGNyb2NuY2wxczRnZ3EyenV6dndnNWs4dm54Mnhmd3RkbTRjejZ3dG51cWtsN2E=",
+            "index": true
+          }
+        ]
+      }
+    ],
+    "end_block_events": null,
+    "validator_updates": null,
+    "consensus_param_updates": {
+      "block": {
+        "max_bytes": "500000",
+        "max_gas": "81500000"
+      },
+      "evidence": {
+        "max_age_num_blocks": "403200",
+        "max_age_duration": "2419200000000000",
+        "max_bytes": "150000"
+      },
+      "validator": {
+        "pub_key_types": [
+          "ed25519"
+        ]
+      }
+    }
+  }
+}
+`

--- a/usecase/parser/test/tx_msg_exec/tx_msg_exec_msg_set_withdraw_address.go
+++ b/usecase/parser/test/tx_msg_exec/tx_msg_exec_msg_set_withdraw_address.go
@@ -1,0 +1,464 @@
+package usecase_parser_test
+
+const TX_MSG_EXEC_MSG_SET_WITHDRAW_ADDRESS_BLOCK_RESP = `
+{
+    "jsonrpc": "2.0",
+    "id": -1,
+    "result": {
+        "block_id": {
+            "hash": "03263B69D5AAF9BC9952477DF72BAAF2B578E0CCC5E184103148B13B69B3389D",
+            "parts": {
+                "total": 1,
+                "hash": "6501FF7A2E2B1270188B6100914734A10FAC6475FFB98562BE2D37F74D29D5A7"
+            }
+        },
+        "block": {
+            "header": {
+                "version": {
+                    "block": "11"
+                },
+                "chain_id": "chaintest",
+                "height": "292",
+                "time": "2022-08-11T08:26:54.360681Z",
+                "last_block_id": {
+                    "hash": "84BB867F07C7A6EC81B20599F2F20E9A795257335B120CEBECB0BB5FDF5E3CF2",
+                    "parts": {
+                        "total": 1,
+                        "hash": "007061C1BC5B26B8D6A99D7C3E4133F6B5D1DBA637FEB95CEFEDDA37180BD4E1"
+                    }
+                },
+                "last_commit_hash": "66BFF84634FEAD8DB8AB76CEEDC65919513B935DC2E1D3BA1F57DFC8ABE54302",
+                "data_hash": "677F2B86E71F84545D73EBF8449794CB04895411B2EFF78EB31F4EAE2AFADE55",
+                "validators_hash": "D179F82943E9BA4C392F1A3A75F75670098576F035DC973B1FBC21F816A84CC5",
+                "next_validators_hash": "D179F82943E9BA4C392F1A3A75F75670098576F035DC973B1FBC21F816A84CC5",
+                "consensus_hash": "048091BC7DDC283F77BFBF91D73C44DA58C3DF8A9CBC867405D8B7F3DAADA22F",
+                "app_hash": "29B03993F27E581FC1C0650B2E3E264342574C44612F5FB9458F117B1797EF34",
+                "last_results_hash": "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
+                "evidence_hash": "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
+                "proposer_address": "F288243EE77CDC90BF8BBDA4F3D75163A8C8E589"
+            },
+            "data": {
+                "txs": [
+                    "CuIBCt8BCh0vY29zbW9zLmF1dGh6LnYxYmV0YTEuTXNnRXhlYxK9AQoqY3JvMTQwNnkwMDluNDNhd2EwZTVuNnQydDA2YTh0dHk5YXpwdTlhdDI1Eo4BCjIvY29zbW9zLmRpc3RyaWJ1dGlvbi52MWJldGExLk1zZ1NldFdpdGhkcmF3QWRkcmVzcxJYCipjcm8xaHRxc3hmajRrOWhoYWd0dmxtcXg2bDRqNTkzcHpkazdkZHY1MG4SKmNybzE0MDZ5MDA5bjQzYXdhMGU1bjZ0MnQwNmE4dHR5OWF6cHU5YXQyNRJYClAKRgofL2Nvc21vcy5jcnlwdG8uc2VjcDI1NmsxLlB1YktleRIjCiEDa3xk3e9GkCLsgl2gTlR1Dbx3XWHtJKygFqjy58DXn64SBAoCCAEYAxIEEMCaDBpALNJps5yQJ8AJXnf53XJcrN2DbXSbWMxE/e82rhm0as8S/vTIWZUCVIaDxSCDKt09mlYRwwDSAZOfW6XGh/6p5Q=="
+                ]
+            },
+            "evidence": {
+                "evidence": []
+            },
+            "last_commit": {
+                "height": "291",
+                "round": 0,
+                "block_id": {
+                    "hash": "84BB867F07C7A6EC81B20599F2F20E9A795257335B120CEBECB0BB5FDF5E3CF2",
+                    "parts": {
+                        "total": 1,
+                        "hash": "007061C1BC5B26B8D6A99D7C3E4133F6B5D1DBA637FEB95CEFEDDA37180BD4E1"
+                    }
+                },
+                "signatures": [
+                    {
+                        "block_id_flag": 2,
+                        "validator_address": "0737362FA0CB60BBEC339BBA31F25FE6BD363ED0",
+                        "timestamp": "2022-08-11T08:26:54.360681Z",
+                        "signature": "xDkTXjfirZahCf0c5a4ls3qhgVheQKsAQdKMwlT7HoaLSCcgctFaeI+Z3zcqGKXAn0yTIbVSmjIJ4xRFDa1GBQ=="
+                    },
+                    {
+                        "block_id_flag": 2,
+                        "validator_address": "F288243EE77CDC90BF8BBDA4F3D75163A8C8E589",
+                        "timestamp": "2022-08-11T08:26:54.3967Z",
+                        "signature": "r2AgkWmmMr4X0FT1f0/7k2aqX9Sp5dGN4zBO5LTYeAQ9ca0G2HNO7PNdSISU0we7WMi1XxHSiWdvV/G51U88Bw=="
+                    }
+                ]
+            }
+        }
+    }
+}
+`
+
+const TX_MSG_EXEC_MSG_SET_WITHDRAW_ADDRESS_BLOCK_RESULTS_RESP = `
+{
+    "jsonrpc": "2.0",
+    "id": -1,
+    "result": {
+        "height": "292",
+        "txs_results": [
+            {
+                "code": 0,
+                "data": "CiMKHS9jb3Ntb3MuYXV0aHoudjFiZXRhMS5Nc2dFeGVjEgIKAA==",
+                "log": "[{\"events\":[{\"type\":\"message\",\"attributes\":[{\"key\":\"action\",\"value\":\"/cosmos.authz.v1beta1.MsgExec\"},{\"key\":\"module\",\"value\":\"distribution\"},{\"key\":\"sender\",\"value\":\"cro1htqsxfj4k9hhagtvlmqx6l4j593pzdk7ddv50n\"}]},{\"type\":\"set_withdraw_address\",\"attributes\":[{\"key\":\"withdraw_address\",\"value\":\"cro1406y009n43awa0e5n6t2t06a8tty9azpu9at25\"}]}]}]",
+                "info": "",
+                "gas_wanted": "200000",
+                "gas_used": "47394",
+                "events": [
+                    {
+                        "type": "tx",
+                        "attributes": [
+                            {
+                                "key": "ZmVl",
+                                "value": null,
+                                "index": true
+                            }
+                        ]
+                    },
+                    {
+                        "type": "tx",
+                        "attributes": [
+                            {
+                                "key": "YWNjX3NlcQ==",
+                                "value": "Y3JvMTQwNnkwMDluNDNhd2EwZTVuNnQydDA2YTh0dHk5YXpwdTlhdDI1LzM=",
+                                "index": true
+                            }
+                        ]
+                    },
+                    {
+                        "type": "tx",
+                        "attributes": [
+                            {
+                                "key": "c2lnbmF0dXJl",
+                                "value": "TE5KcHM1eVFKOEFKWG5mNTNYSmNyTjJEYlhTYldNeEUvZTgycmhtMGFzOFMvdlRJV1pVQ1ZJYUR4U0NES3QwOW1sWVJ3d0RTQVpPZlc2WEdoLzZwNVE9PQ==",
+                                "index": true
+                            }
+                        ]
+                    },
+                    {
+                        "type": "message",
+                        "attributes": [
+                            {
+                                "key": "YWN0aW9u",
+                                "value": "L2Nvc21vcy5hdXRoei52MWJldGExLk1zZ0V4ZWM=",
+                                "index": true
+                            }
+                        ]
+                    },
+                    {
+                        "type": "set_withdraw_address",
+                        "attributes": [
+                            {
+                                "key": "d2l0aGRyYXdfYWRkcmVzcw==",
+                                "value": "Y3JvMTQwNnkwMDluNDNhd2EwZTVuNnQydDA2YTh0dHk5YXpwdTlhdDI1",
+                                "index": true
+                            }
+                        ]
+                    },
+                    {
+                        "type": "message",
+                        "attributes": [
+                            {
+                                "key": "bW9kdWxl",
+                                "value": "ZGlzdHJpYnV0aW9u",
+                                "index": true
+                            },
+                            {
+                                "key": "c2VuZGVy",
+                                "value": "Y3JvMWh0cXN4Zmo0azloaGFndHZsbXF4Nmw0ajU5M3B6ZGs3ZGR2NTBu",
+                                "index": true
+                            }
+                        ]
+                    }
+                ],
+                "codespace": ""
+            }
+        ],
+        "begin_block_events": [
+            {
+                "type": "coin_received",
+                "attributes": [
+                    {
+                        "key": "cmVjZWl2ZXI=",
+                        "value": "Y3JvMW0zaDMwd2x2c2Y4bGxydXh0cHVrZHZzeTBrbTJrdW04czIwcG0z",
+                        "index": true
+                    },
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MzQyMzRiYXNlY3Jv",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "coinbase",
+                "attributes": [
+                    {
+                        "key": "bWludGVy",
+                        "value": "Y3JvMW0zaDMwd2x2c2Y4bGxydXh0cHVrZHZzeTBrbTJrdW04czIwcG0z",
+                        "index": true
+                    },
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MzQyMzRiYXNlY3Jv",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "coin_spent",
+                "attributes": [
+                    {
+                        "key": "c3BlbmRlcg==",
+                        "value": "Y3JvMW0zaDMwd2x2c2Y4bGxydXh0cHVrZHZzeTBrbTJrdW04czIwcG0z",
+                        "index": true
+                    },
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MzQyMzRiYXNlY3Jv",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "coin_received",
+                "attributes": [
+                    {
+                        "key": "cmVjZWl2ZXI=",
+                        "value": "Y3JvMTd4cGZ2YWttMmFtZzk2MnlsczZmODR6M2tlbGw4YzVsZ3p0ZWh2",
+                        "index": true
+                    },
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MzQyMzRiYXNlY3Jv",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "transfer",
+                "attributes": [
+                    {
+                        "key": "cmVjaXBpZW50",
+                        "value": "Y3JvMTd4cGZ2YWttMmFtZzk2MnlsczZmODR6M2tlbGw4YzVsZ3p0ZWh2",
+                        "index": true
+                    },
+                    {
+                        "key": "c2VuZGVy",
+                        "value": "Y3JvMW0zaDMwd2x2c2Y4bGxydXh0cHVrZHZzeTBrbTJrdW04czIwcG0z",
+                        "index": true
+                    },
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MzQyMzRiYXNlY3Jv",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "message",
+                "attributes": [
+                    {
+                        "key": "c2VuZGVy",
+                        "value": "Y3JvMW0zaDMwd2x2c2Y4bGxydXh0cHVrZHZzeTBrbTJrdW04czIwcG0z",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "mint",
+                "attributes": [
+                    {
+                        "key": "Ym9uZGVkX3JhdGlv",
+                        "value": "MC4wMDEyMDMzNjIyMjE2MTgxNTU=",
+                        "index": true
+                    },
+                    {
+                        "key": "aW5mbGF0aW9u",
+                        "value": "MC4xMzAwMDYwMDM1OTY3OTQ5OTQ=",
+                        "index": true
+                    },
+                    {
+                        "key": "YW5udWFsX3Byb3Zpc2lvbnM=",
+                        "value": "MjE2MDcxMjczMDczLjQ5OTk5NDYzMDcyNjM1OTExNg==",
+                        "index": true
+                    },
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MzQyMzQ=",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "coin_spent",
+                "attributes": [
+                    {
+                        "key": "c3BlbmRlcg==",
+                        "value": "Y3JvMTd4cGZ2YWttMmFtZzk2MnlsczZmODR6M2tlbGw4YzVsZ3p0ZWh2",
+                        "index": true
+                    },
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MzQyMzRiYXNlY3Jv",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "coin_received",
+                "attributes": [
+                    {
+                        "key": "cmVjZWl2ZXI=",
+                        "value": "Y3JvMWp2NjVzM2dycWY2djZqbDNkcDR0NmM5dDlyazk5Y2Q4bHl2OTR3",
+                        "index": true
+                    },
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MzQyMzRiYXNlY3Jv",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "transfer",
+                "attributes": [
+                    {
+                        "key": "cmVjaXBpZW50",
+                        "value": "Y3JvMWp2NjVzM2dycWY2djZqbDNkcDR0NmM5dDlyazk5Y2Q4bHl2OTR3",
+                        "index": true
+                    },
+                    {
+                        "key": "c2VuZGVy",
+                        "value": "Y3JvMTd4cGZ2YWttMmFtZzk2MnlsczZmODR6M2tlbGw4YzVsZ3p0ZWh2",
+                        "index": true
+                    },
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MzQyMzRiYXNlY3Jv",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "message",
+                "attributes": [
+                    {
+                        "key": "c2VuZGVy",
+                        "value": "Y3JvMTd4cGZ2YWttMmFtZzk2MnlsczZmODR6M2tlbGw4YzVsZ3p0ZWh2",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "proposer_reward",
+                "attributes": [
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MTcxMS43MDAwMDAwMDAwMDAwMDAwMDBiYXNlY3Jv",
+                        "index": true
+                    },
+                    {
+                        "key": "dmFsaWRhdG9y",
+                        "value": "Y3JvY25jbDE3Y3llNWdtZWFsbXBnejN0Y2xmamdhN3VyZGp4ajZuYWgzdTh3Mg==",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "commission",
+                "attributes": [
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MTcxLjE3MDAwMDAwMDAwMDAwMDAwMGJhc2Vjcm8=",
+                        "index": true
+                    },
+                    {
+                        "key": "dmFsaWRhdG9y",
+                        "value": "Y3JvY25jbDE3Y3llNWdtZWFsbXBnejN0Y2xmamdhN3VyZGp4ajZuYWgzdTh3Mg==",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "rewards",
+                "attributes": [
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MTcxMS43MDAwMDAwMDAwMDAwMDAwMDBiYXNlY3Jv",
+                        "index": true
+                    },
+                    {
+                        "key": "dmFsaWRhdG9y",
+                        "value": "Y3JvY25jbDE3Y3llNWdtZWFsbXBnejN0Y2xmamdhN3VyZGp4ajZuYWgzdTh3Mg==",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "commission",
+                "attributes": [
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MTU5MS44ODEwMDAwMDAwMDAwMDAwMDBiYXNlY3Jv",
+                        "index": true
+                    },
+                    {
+                        "key": "dmFsaWRhdG9y",
+                        "value": "Y3JvY25jbDE3Y3llNWdtZWFsbXBnejN0Y2xmamdhN3VyZGp4ajZuYWgzdTh3Mg==",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "rewards",
+                "attributes": [
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MTU5MTguODEwMDAwMDAwMDAwMDAwMDAwYmFzZWNybw==",
+                        "index": true
+                    },
+                    {
+                        "key": "dmFsaWRhdG9y",
+                        "value": "Y3JvY25jbDE3Y3llNWdtZWFsbXBnejN0Y2xmamdhN3VyZGp4ajZuYWgzdTh3Mg==",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "commission",
+                "attributes": [
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MTU5MS44ODEwMDAwMDAwMDAwMDAwMDBiYXNlY3Jv",
+                        "index": true
+                    },
+                    {
+                        "key": "dmFsaWRhdG9y",
+                        "value": "Y3JvY25jbDFodHFzeGZqNGs5aGhhZ3R2bG1xeDZsNGo1OTNwemRrN3dxMGFkMA==",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "rewards",
+                "attributes": [
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MTU5MTguODEwMDAwMDAwMDAwMDAwMDAwYmFzZWNybw==",
+                        "index": true
+                    },
+                    {
+                        "key": "dmFsaWRhdG9y",
+                        "value": "Y3JvY25jbDFodHFzeGZqNGs5aGhhZ3R2bG1xeDZsNGo1OTNwemRrN3dxMGFkMA==",
+                        "index": true
+                    }
+                ]
+            }
+        ],
+        "end_block_events": null,
+        "validator_updates": null,
+        "consensus_param_updates": {
+            "block": {
+                "max_bytes": "22020096",
+                "max_gas": "-1"
+            },
+            "evidence": {
+                "max_age_num_blocks": "100000",
+                "max_age_duration": "172800000000000",
+                "max_bytes": "1048576"
+            },
+            "validator": {
+                "pub_key_types": [
+                    "ed25519"
+                ]
+            }
+        }
+    }
+}
+`

--- a/usecase/parser/test/tx_msg_exec/tx_msg_exec_msg_withdraw_delegator_reward.go
+++ b/usecase/parser/test/tx_msg_exec/tx_msg_exec_msg_withdraw_delegator_reward.go
@@ -1,0 +1,559 @@
+package usecase_parser_test
+
+const TX_MSG_EXEC_MSG_WITHDRAW_DELEGATOR_REWARD_BLOCK_RESP = `
+{
+    "jsonrpc": "2.0",
+    "id": -1,
+    "result": {
+        "block_id": {
+            "hash": "ABADA3C9E4E43B019EEE4CD2A7FD9EFEA0F8968C9D62915615E0C20F3D8CBEFC",
+            "parts": {
+                "total": 1,
+                "hash": "FEB80A021E4361105437B636AC163F2F3D6E2312E194F06C90F44384B6D80610"
+            }
+        },
+        "block": {
+            "header": {
+                "version": {
+                    "block": "11"
+                },
+                "chain_id": "chaintest",
+                "height": "313",
+                "time": "2022-08-11T09:10:07.111359Z",
+                "last_block_id": {
+                    "hash": "7D37C7B0D7951DF33C9FB8325FBD3195273283844F58DD635EE6670CCEF07699",
+                    "parts": {
+                        "total": 1,
+                        "hash": "E7B1758C470956AB30ADD1EEF6D05628FF53F9CC2A609F69B620634FCDA2F31B"
+                    }
+                },
+                "last_commit_hash": "978B717F13BF769FB299BE09244B5E954627E41F6E0BF57CADD57C1728BA5285",
+                "data_hash": "6EDB8920F3922910E0351E4B4CBA40DFBA493584608BF6B06F5C7DF9C34C3701",
+                "validators_hash": "3CC6A79299D004B413B5701492B3CC3BCB0A44DC245AB40E92E4D3A7F38D44C9",
+                "next_validators_hash": "3CC6A79299D004B413B5701492B3CC3BCB0A44DC245AB40E92E4D3A7F38D44C9",
+                "consensus_hash": "048091BC7DDC283F77BFBF91D73C44DA58C3DF8A9CBC867405D8B7F3DAADA22F",
+                "app_hash": "56F6964C4476F01DEC0E546A701302896469017E1BF46E60AD39D96ADD63C0DB",
+                "last_results_hash": "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
+                "evidence_hash": "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
+                "proposer_address": "1BA1E260F60A3A76B51CD36CB92026402D49A031"
+            },
+            "data": {
+                "txs": [
+                    "CoUDCoIDCh0vY29zbW9zLmF1dGh6LnYxYmV0YTEuTXNnRXhlYxLgAgoqY3JvMWh0cXN4Zmo0azloaGFndHZsbXF4Nmw0ajU5M3B6ZGs3ZGR2NTBuEpcBCjcvY29zbW9zLmRpc3RyaWJ1dGlvbi52MWJldGExLk1zZ1dpdGhkcmF3RGVsZWdhdG9yUmV3YXJkElwKKmNybzFodHFzeGZqNGs5aGhhZ3R2bG1xeDZsNGo1OTNwemRrN2RkdjUwbhIuY3JvY25jbDFodHFzeGZqNGs5aGhhZ3R2bG1xeDZsNGo1OTNwemRrN3dxMGFkMBKXAQo3L2Nvc21vcy5kaXN0cmlidXRpb24udjFiZXRhMS5Nc2dXaXRoZHJhd0RlbGVnYXRvclJld2FyZBJcCipjcm8xaHRxc3hmajRrOWhoYWd0dmxtcXg2bDRqNTkzcHpkazdkZHY1MG4SLmNyb2NuY2wxN2N5ZTVnbWVhbG1wZ3ozdGNsZmpnYTd1cmRqeGo2bmFoM3U4dzISWApQCkYKHy9jb3Ntb3MuY3J5cHRvLnNlY3AyNTZrMS5QdWJLZXkSIwohAzwKY/mjHju6d7GSvY/oTu62ILJwQ+ZdCiAOadX5F366EgQKAggBGAMSBBDAmgwaQCKdcfyXIPQOrVuiaZZXswnVj5NvAQLYTU33iIH3kAVoMQ7QC03X0FjeMvVLhwzt5cVzjaSdGXERFRXZ8N4sc2Y="
+                ]
+            },
+            "evidence": {
+                "evidence": []
+            },
+            "last_commit": {
+                "height": "312",
+                "round": 0,
+                "block_id": {
+                    "hash": "7D37C7B0D7951DF33C9FB8325FBD3195273283844F58DD635EE6670CCEF07699",
+                    "parts": {
+                        "total": 1,
+                        "hash": "E7B1758C470956AB30ADD1EEF6D05628FF53F9CC2A609F69B620634FCDA2F31B"
+                    }
+                },
+                "signatures": [
+                    {
+                        "block_id_flag": 2,
+                        "validator_address": "1BA1E260F60A3A76B51CD36CB92026402D49A031",
+                        "timestamp": "2022-08-11T09:10:07.111359Z",
+                        "signature": "PQCoHaYCXLYgLoYYLAy49SL6BvGLvYV5wwdvvfUqNzCAY85fPvQoTOnTrg31Bo6QvXpv5P8aIXuzzFWZAJJHBw=="
+                    },
+                    {
+                        "block_id_flag": 2,
+                        "validator_address": "D1483ACF4613CF4450BC0FCEB07F84FE2634A5B1",
+                        "timestamp": "2022-08-11T09:10:07.129718Z",
+                        "signature": "SrzBacorSQbUnovRRcI1R3rbYyRgvh2lUks3FCX5McyDZvRvzLXgd14fNDUAdAMK0mrGGN96M8eOAG9QZXQMBQ=="
+                    }
+                ]
+            }
+        }
+    }
+}
+`
+
+const TX_MSG_EXEC_MSG_WITHDRAW_DELEGATOR_REWARD_BLOCK_RESULTS_RESP = `
+{
+    "jsonrpc": "2.0",
+    "id": -1,
+    "result": {
+        "height": "313",
+        "txs_results": [
+            {
+                "code": 0,
+                "data": "CiUKHS9jb3Ntb3MuYXV0aHoudjFiZXRhMS5Nc2dFeGVjEgQKAAoA",
+                "log": "[{\"events\":[{\"type\":\"coin_received\",\"attributes\":[{\"key\":\"receiver\",\"value\":\"cro1htqsxfj4k9hhagtvlmqx6l4j593pzdk7ddv50n\"},{\"key\":\"amount\",\"value\":\"362332basecro\"}]},{\"type\":\"coin_spent\",\"attributes\":[{\"key\":\"spender\",\"value\":\"cro1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8lyv94w\"},{\"key\":\"amount\",\"value\":\"362332basecro\"}]},{\"type\":\"message\",\"attributes\":[{\"key\":\"action\",\"value\":\"/cosmos.authz.v1beta1.MsgExec\"},{\"key\":\"sender\",\"value\":\"cro1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8lyv94w\"},{\"key\":\"module\",\"value\":\"distribution\"},{\"key\":\"sender\",\"value\":\"cro1htqsxfj4k9hhagtvlmqx6l4j593pzdk7ddv50n\"},{\"key\":\"module\",\"value\":\"distribution\"},{\"key\":\"sender\",\"value\":\"cro1htqsxfj4k9hhagtvlmqx6l4j593pzdk7ddv50n\"}]},{\"type\":\"transfer\",\"attributes\":[{\"key\":\"recipient\",\"value\":\"cro1htqsxfj4k9hhagtvlmqx6l4j593pzdk7ddv50n\"},{\"key\":\"sender\",\"value\":\"cro1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8lyv94w\"},{\"key\":\"amount\",\"value\":\"362332basecro\"}]},{\"type\":\"withdraw_rewards\",\"attributes\":[{\"key\":\"amount\",\"value\":\"362332basecro\"},{\"key\":\"validator\",\"value\":\"crocncl1htqsxfj4k9hhagtvlmqx6l4j593pzdk7wq0ad0\"},{\"key\":\"amount\"},{\"key\":\"validator\",\"value\":\"crocncl17cye5gmealmpgz3tclfjga7urdjxj6nah3u8w2\"}]}]}]",
+                "info": "",
+                "gas_wanted": "200000",
+                "gas_used": "153624",
+                "events": [
+                    {
+                        "type": "tx",
+                        "attributes": [
+                            {
+                                "key": "ZmVl",
+                                "value": null,
+                                "index": true
+                            }
+                        ]
+                    },
+                    {
+                        "type": "tx",
+                        "attributes": [
+                            {
+                                "key": "YWNjX3NlcQ==",
+                                "value": "Y3JvMWh0cXN4Zmo0azloaGFndHZsbXF4Nmw0ajU5M3B6ZGs3ZGR2NTBuLzM=",
+                                "index": true
+                            }
+                        ]
+                    },
+                    {
+                        "type": "tx",
+                        "attributes": [
+                            {
+                                "key": "c2lnbmF0dXJl",
+                                "value": "SXAxeC9KY2c5QTZ0VzZKcGxsZXpDZFdQazI4QkF0aE5UZmVJZ2ZlUUJXZ3hEdEFMVGRmUVdONHk5VXVIRE8zbHhYT05wSjBaY1JFVkZkbnczaXh6Wmc9PQ==",
+                                "index": true
+                            }
+                        ]
+                    },
+                    {
+                        "type": "message",
+                        "attributes": [
+                            {
+                                "key": "YWN0aW9u",
+                                "value": "L2Nvc21vcy5hdXRoei52MWJldGExLk1zZ0V4ZWM=",
+                                "index": true
+                            }
+                        ]
+                    },
+                    {
+                        "type": "coin_spent",
+                        "attributes": [
+                            {
+                                "key": "c3BlbmRlcg==",
+                                "value": "Y3JvMWp2NjVzM2dycWY2djZqbDNkcDR0NmM5dDlyazk5Y2Q4bHl2OTR3",
+                                "index": true
+                            },
+                            {
+                                "key": "YW1vdW50",
+                                "value": "MzYyMzMyYmFzZWNybw==",
+                                "index": true
+                            }
+                        ]
+                    },
+                    {
+                        "type": "coin_received",
+                        "attributes": [
+                            {
+                                "key": "cmVjZWl2ZXI=",
+                                "value": "Y3JvMWh0cXN4Zmo0azloaGFndHZsbXF4Nmw0ajU5M3B6ZGs3ZGR2NTBu",
+                                "index": true
+                            },
+                            {
+                                "key": "YW1vdW50",
+                                "value": "MzYyMzMyYmFzZWNybw==",
+                                "index": true
+                            }
+                        ]
+                    },
+                    {
+                        "type": "transfer",
+                        "attributes": [
+                            {
+                                "key": "cmVjaXBpZW50",
+                                "value": "Y3JvMWh0cXN4Zmo0azloaGFndHZsbXF4Nmw0ajU5M3B6ZGs3ZGR2NTBu",
+                                "index": true
+                            },
+                            {
+                                "key": "c2VuZGVy",
+                                "value": "Y3JvMWp2NjVzM2dycWY2djZqbDNkcDR0NmM5dDlyazk5Y2Q4bHl2OTR3",
+                                "index": true
+                            },
+                            {
+                                "key": "YW1vdW50",
+                                "value": "MzYyMzMyYmFzZWNybw==",
+                                "index": true
+                            }
+                        ]
+                    },
+                    {
+                        "type": "message",
+                        "attributes": [
+                            {
+                                "key": "c2VuZGVy",
+                                "value": "Y3JvMWp2NjVzM2dycWY2djZqbDNkcDR0NmM5dDlyazk5Y2Q4bHl2OTR3",
+                                "index": true
+                            }
+                        ]
+                    },
+                    {
+                        "type": "withdraw_rewards",
+                        "attributes": [
+                            {
+                                "key": "YW1vdW50",
+                                "value": "MzYyMzMyYmFzZWNybw==",
+                                "index": true
+                            },
+                            {
+                                "key": "dmFsaWRhdG9y",
+                                "value": "Y3JvY25jbDFodHFzeGZqNGs5aGhhZ3R2bG1xeDZsNGo1OTNwemRrN3dxMGFkMA==",
+                                "index": true
+                            }
+                        ]
+                    },
+                    {
+                        "type": "message",
+                        "attributes": [
+                            {
+                                "key": "bW9kdWxl",
+                                "value": "ZGlzdHJpYnV0aW9u",
+                                "index": true
+                            },
+                            {
+                                "key": "c2VuZGVy",
+                                "value": "Y3JvMWh0cXN4Zmo0azloaGFndHZsbXF4Nmw0ajU5M3B6ZGs3ZGR2NTBu",
+                                "index": true
+                            }
+                        ]
+                    },
+                    {
+                        "type": "withdraw_rewards",
+                        "attributes": [
+                            {
+                                "key": "YW1vdW50",
+                                "value": null,
+                                "index": true
+                            },
+                            {
+                                "key": "dmFsaWRhdG9y",
+                                "value": "Y3JvY25jbDE3Y3llNWdtZWFsbXBnejN0Y2xmamdhN3VyZGp4ajZuYWgzdTh3Mg==",
+                                "index": true
+                            }
+                        ]
+                    },
+                    {
+                        "type": "message",
+                        "attributes": [
+                            {
+                                "key": "bW9kdWxl",
+                                "value": "ZGlzdHJpYnV0aW9u",
+                                "index": true
+                            },
+                            {
+                                "key": "c2VuZGVy",
+                                "value": "Y3JvMWh0cXN4Zmo0azloaGFndHZsbXF4Nmw0ajU5M3B6ZGs3ZGR2NTBu",
+                                "index": true
+                            }
+                        ]
+                    }
+                ],
+                "codespace": ""
+            }
+        ],
+        "begin_block_events": [
+            {
+                "type": "coin_received",
+                "attributes": [
+                    {
+                        "key": "cmVjZWl2ZXI=",
+                        "value": "Y3JvMW0zaDMwd2x2c2Y4bGxydXh0cHVrZHZzeTBrbTJrdW04czIwcG0z",
+                        "index": true
+                    },
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MzQyMzRiYXNlY3Jv",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "coinbase",
+                "attributes": [
+                    {
+                        "key": "bWludGVy",
+                        "value": "Y3JvMW0zaDMwd2x2c2Y4bGxydXh0cHVrZHZzeTBrbTJrdW04czIwcG0z",
+                        "index": true
+                    },
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MzQyMzRiYXNlY3Jv",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "coin_spent",
+                "attributes": [
+                    {
+                        "key": "c3BlbmRlcg==",
+                        "value": "Y3JvMW0zaDMwd2x2c2Y4bGxydXh0cHVrZHZzeTBrbTJrdW04czIwcG0z",
+                        "index": true
+                    },
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MzQyMzRiYXNlY3Jv",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "coin_received",
+                "attributes": [
+                    {
+                        "key": "cmVjZWl2ZXI=",
+                        "value": "Y3JvMTd4cGZ2YWttMmFtZzk2MnlsczZmODR6M2tlbGw4YzVsZ3p0ZWh2",
+                        "index": true
+                    },
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MzQyMzRiYXNlY3Jv",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "transfer",
+                "attributes": [
+                    {
+                        "key": "cmVjaXBpZW50",
+                        "value": "Y3JvMTd4cGZ2YWttMmFtZzk2MnlsczZmODR6M2tlbGw4YzVsZ3p0ZWh2",
+                        "index": true
+                    },
+                    {
+                        "key": "c2VuZGVy",
+                        "value": "Y3JvMW0zaDMwd2x2c2Y4bGxydXh0cHVrZHZzeTBrbTJrdW04czIwcG0z",
+                        "index": true
+                    },
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MzQyMzRiYXNlY3Jv",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "message",
+                "attributes": [
+                    {
+                        "key": "c2VuZGVy",
+                        "value": "Y3JvMW0zaDMwd2x2c2Y4bGxydXh0cHVrZHZzeTBrbTJrdW04czIwcG0z",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "mint",
+                "attributes": [
+                    {
+                        "key": "Ym9uZGVkX3JhdGlv",
+                        "value": "MC4wMDEyMDMzNjE3MDE2OTczMzk=",
+                        "index": true
+                    },
+                    {
+                        "key": "aW5mbGF0aW9u",
+                        "value": "MC4xMzAwMDY0MzUzNjIzMjA0MjM=",
+                        "index": true
+                    },
+                    {
+                        "key": "YW5udWFsX3Byb3Zpc2lvbnM=",
+                        "value": "MjE2MDcyMDg0MTM1LjU1MDg5NzU1MTg4NjkwNzk0NA==",
+                        "index": true
+                    },
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MzQyMzQ=",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "coin_spent",
+                "attributes": [
+                    {
+                        "key": "c3BlbmRlcg==",
+                        "value": "Y3JvMTd4cGZ2YWttMmFtZzk2MnlsczZmODR6M2tlbGw4YzVsZ3p0ZWh2",
+                        "index": true
+                    },
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MzQyMzRiYXNlY3Jv",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "coin_received",
+                "attributes": [
+                    {
+                        "key": "cmVjZWl2ZXI=",
+                        "value": "Y3JvMWp2NjVzM2dycWY2djZqbDNkcDR0NmM5dDlyazk5Y2Q4bHl2OTR3",
+                        "index": true
+                    },
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MzQyMzRiYXNlY3Jv",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "transfer",
+                "attributes": [
+                    {
+                        "key": "cmVjaXBpZW50",
+                        "value": "Y3JvMWp2NjVzM2dycWY2djZqbDNkcDR0NmM5dDlyazk5Y2Q4bHl2OTR3",
+                        "index": true
+                    },
+                    {
+                        "key": "c2VuZGVy",
+                        "value": "Y3JvMTd4cGZ2YWttMmFtZzk2MnlsczZmODR6M2tlbGw4YzVsZ3p0ZWh2",
+                        "index": true
+                    },
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MzQyMzRiYXNlY3Jv",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "message",
+                "attributes": [
+                    {
+                        "key": "c2VuZGVy",
+                        "value": "Y3JvMTd4cGZ2YWttMmFtZzk2MnlsczZmODR6M2tlbGw4YzVsZ3p0ZWh2",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "proposer_reward",
+                "attributes": [
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MTcxMS43MDAwMDAwMDAwMDAwMDAwMDBiYXNlY3Jv",
+                        "index": true
+                    },
+                    {
+                        "key": "dmFsaWRhdG9y",
+                        "value": "Y3JvY25jbDE3Y3llNWdtZWFsbXBnejN0Y2xmamdhN3VyZGp4ajZuYWgzdTh3Mg==",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "commission",
+                "attributes": [
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MTcxLjE3MDAwMDAwMDAwMDAwMDAwMGJhc2Vjcm8=",
+                        "index": true
+                    },
+                    {
+                        "key": "dmFsaWRhdG9y",
+                        "value": "Y3JvY25jbDE3Y3llNWdtZWFsbXBnejN0Y2xmamdhN3VyZGp4ajZuYWgzdTh3Mg==",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "rewards",
+                "attributes": [
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MTcxMS43MDAwMDAwMDAwMDAwMDAwMDBiYXNlY3Jv",
+                        "index": true
+                    },
+                    {
+                        "key": "dmFsaWRhdG9y",
+                        "value": "Y3JvY25jbDE3Y3llNWdtZWFsbXBnejN0Y2xmamdhN3VyZGp4ajZuYWgzdTh3Mg==",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "commission",
+                "attributes": [
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MTU5MS44ODEwMDAwMDAwMDAwMDAwMDBiYXNlY3Jv",
+                        "index": true
+                    },
+                    {
+                        "key": "dmFsaWRhdG9y",
+                        "value": "Y3JvY25jbDFodHFzeGZqNGs5aGhhZ3R2bG1xeDZsNGo1OTNwemRrN3dxMGFkMA==",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "rewards",
+                "attributes": [
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MTU5MTguODEwMDAwMDAwMDAwMDAwMDAwYmFzZWNybw==",
+                        "index": true
+                    },
+                    {
+                        "key": "dmFsaWRhdG9y",
+                        "value": "Y3JvY25jbDFodHFzeGZqNGs5aGhhZ3R2bG1xeDZsNGo1OTNwemRrN3dxMGFkMA==",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "commission",
+                "attributes": [
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MTU5MS44ODEwMDAwMDAwMDAwMDAwMDBiYXNlY3Jv",
+                        "index": true
+                    },
+                    {
+                        "key": "dmFsaWRhdG9y",
+                        "value": "Y3JvY25jbDE3Y3llNWdtZWFsbXBnejN0Y2xmamdhN3VyZGp4ajZuYWgzdTh3Mg==",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "rewards",
+                "attributes": [
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MTU5MTguODEwMDAwMDAwMDAwMDAwMDAwYmFzZWNybw==",
+                        "index": true
+                    },
+                    {
+                        "key": "dmFsaWRhdG9y",
+                        "value": "Y3JvY25jbDE3Y3llNWdtZWFsbXBnejN0Y2xmamdhN3VyZGp4ajZuYWgzdTh3Mg==",
+                        "index": true
+                    }
+                ]
+            }
+        ],
+        "end_block_events": null,
+        "validator_updates": null,
+        "consensus_param_updates": {
+            "block": {
+                "max_bytes": "22020096",
+                "max_gas": "-1"
+            },
+            "evidence": {
+                "max_age_num_blocks": "100000",
+                "max_age_duration": "172800000000000",
+                "max_bytes": "1048576"
+            },
+            "validator": {
+                "pub_key_types": [
+                    "ed25519"
+                ]
+            }
+        }
+    }
+}
+`

--- a/usecase/parser/test/tx_msg_exec/tx_msg_exec_msg_withdraw_validator_commission.go
+++ b/usecase/parser/test/tx_msg_exec/tx_msg_exec_msg_withdraw_validator_commission.go
@@ -1,0 +1,614 @@
+package usecase_parser_test
+
+const TX_MSG_EXEC_MSG_WITHDRAW_VALIDATOR_COMMISSION_BLOCK_RESP = `
+{
+    "jsonrpc": "2.0",
+    "id": -1,
+    "result": {
+        "block_id": {
+            "hash": "94727699F5F489DEE28C94D6B0E3C8B503EA742B5307B187C30DF233FD6E334B",
+            "parts": {
+                "total": 1,
+                "hash": "D22B5D67F5F71D8996DAD52D74F1064314A02F44F64C9CD1950FE05F089AB92F"
+            }
+        },
+        "block": {
+            "header": {
+                "version": {
+                    "block": "11"
+                },
+                "chain_id": "chaintest",
+                "height": "5991",
+                "time": "2022-08-12T02:59:57.09639Z",
+                "last_block_id": {
+                    "hash": "632C790AB185E8D5C6D3129579D49D56BCED17E1D47C9CFA88A4BE295D231148",
+                    "parts": {
+                        "total": 1,
+                        "hash": "18D6C5A6872B6C62D504C5FBCCE53812EA911AC56CDDAC12DFCD05E165611CC6"
+                    }
+                },
+                "last_commit_hash": "D4570C1D0AFFE51426301B0B4CB6907B03074827CCB1BA5B24ED4B868DC746FC",
+                "data_hash": "43B7683878C0235CEE8F88DE67660ECE8B940FCDEA4F3AA3ED88DF6BC2E762E9",
+                "validators_hash": "9797875DD992FE368DA8CB7A1A6C04F8F09B5F667332108571700DBDE676B8D8",
+                "next_validators_hash": "9797875DD992FE368DA8CB7A1A6C04F8F09B5F667332108571700DBDE676B8D8",
+                "consensus_hash": "048091BC7DDC283F77BFBF91D73C44DA58C3DF8A9CBC867405D8B7F3DAADA22F",
+                "app_hash": "A69E1D8D43AF188CD99FC9E6031D85BEDF30F26A66EB9CFFCB6616150DDA67CB",
+                "last_results_hash": "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
+                "evidence_hash": "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
+                "proposer_address": "42404550EC84BDC92FE4A309740FE93DA1E98A1B"
+            },
+            "data": {
+                "txs": [
+                    "CtwCCtkCCh0vY29zbW9zLmF1dGh6LnYxYmV0YTEuTXNnRXhlYxK3AgoqY3JvMTQwNnkwMDluNDNhd2EwZTVuNnQydDA2YTh0dHk5YXpwdTlhdDI1EpcBCjcvY29zbW9zLmRpc3RyaWJ1dGlvbi52MWJldGExLk1zZ1dpdGhkcmF3RGVsZWdhdG9yUmV3YXJkElwKKmNybzFodHFzeGZqNGs5aGhhZ3R2bG1xeDZsNGo1OTNwemRrN2RkdjUwbhIuY3JvY25jbDFodHFzeGZqNGs5aGhhZ3R2bG1xeDZsNGo1OTNwemRrN3dxMGFkMBJvCjsvY29zbW9zLmRpc3RyaWJ1dGlvbi52MWJldGExLk1zZ1dpdGhkcmF3VmFsaWRhdG9yQ29tbWlzc2lvbhIwCi5jcm9jbmNsMWh0cXN4Zmo0azloaGFndHZsbXF4Nmw0ajU5M3B6ZGs3d3EwYWQwElgKUApGCh8vY29zbW9zLmNyeXB0by5zZWNwMjU2azEuUHViS2V5EiMKIQNrfGTd70aQIuyCXaBOVHUNvHddYe0krKAWqPLnwNefrhIECgIIARgQEgQQwJoMGkDMONvP4mTQflkVF6GtC7TvzPHDSBwt9OoYzYgd78EAPzvsQb0HTzf7JNTcFltR/900Mo1c5k3FDWkIFxK9ztBY"
+                ]
+            },
+            "evidence": {
+                "evidence": []
+            },
+            "last_commit": {
+                "height": "5990",
+                "round": 0,
+                "block_id": {
+                    "hash": "632C790AB185E8D5C6D3129579D49D56BCED17E1D47C9CFA88A4BE295D231148",
+                    "parts": {
+                        "total": 1,
+                        "hash": "18D6C5A6872B6C62D504C5FBCCE53812EA911AC56CDDAC12DFCD05E165611CC6"
+                    }
+                },
+                "signatures": [
+                    {
+                        "block_id_flag": 2,
+                        "validator_address": "42404550EC84BDC92FE4A309740FE93DA1E98A1B",
+                        "timestamp": "2022-08-12T02:59:57.09639Z",
+                        "signature": "yNz6LZdB/uvsn6JmMWl3dvI5Lz+OeiOc7Vu98pL6vnbMCIIFpjmKh/NGIAyDf4bFdPNGi4i8us7s39XO2LfUBg=="
+                    },
+                    {
+                        "block_id_flag": 2,
+                        "validator_address": "FB8249644B36E76759F42EAE764F5842E779D1EE",
+                        "timestamp": "2022-08-12T02:59:57.180172Z",
+                        "signature": "cnpZUOaMD92bFykK0ISQriFiAK6iMVCeK1YFpM7B1NR0X6oxlXeGtleDyxQHkBi1Kk0KqomxliTteEsArYW5Bg=="
+                    }
+                ]
+            }
+        }
+    }
+}
+`
+
+const TX_MSG_EXEC_MSG_WITHDRAW_VALIDATOR_COMMISSION_BLOCK_RESULTS_RESP = `
+{
+    "jsonrpc": "2.0",
+    "id": -1,
+    "result": {
+        "height": "5991",
+        "txs_results": [
+            {
+                "code": 0,
+                "data": "CiUKHS9jb3Ntb3MuYXV0aHoudjFiZXRhMS5Nc2dFeGVjEgQKAAoA",
+                "log": "[{\"events\":[{\"type\":\"coin_received\",\"attributes\":[{\"key\":\"receiver\",\"value\":\"cro1htqsxfj4k9hhagtvlmqx6l4j593pzdk7ddv50n\"},{\"key\":\"amount\",\"value\":\"1285329basecro\"},{\"key\":\"receiver\",\"value\":\"cro1htqsxfj4k9hhagtvlmqx6l4j593pzdk7ddv50n\"},{\"key\":\"amount\",\"value\":\"142814basecro\"}]},{\"type\":\"coin_spent\",\"attributes\":[{\"key\":\"spender\",\"value\":\"cro1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8lyv94w\"},{\"key\":\"amount\",\"value\":\"1285329basecro\"},{\"key\":\"spender\",\"value\":\"cro1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8lyv94w\"},{\"key\":\"amount\",\"value\":\"142814basecro\"}]},{\"type\":\"message\",\"attributes\":[{\"key\":\"action\",\"value\":\"/cosmos.authz.v1beta1.MsgExec\"},{\"key\":\"sender\",\"value\":\"cro1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8lyv94w\"},{\"key\":\"module\",\"value\":\"distribution\"},{\"key\":\"sender\",\"value\":\"cro1htqsxfj4k9hhagtvlmqx6l4j593pzdk7ddv50n\"},{\"key\":\"sender\",\"value\":\"cro1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8lyv94w\"},{\"key\":\"module\",\"value\":\"distribution\"},{\"key\":\"sender\",\"value\":\"crocncl1htqsxfj4k9hhagtvlmqx6l4j593pzdk7wq0ad0\"}]},{\"type\":\"transfer\",\"attributes\":[{\"key\":\"recipient\",\"value\":\"cro1htqsxfj4k9hhagtvlmqx6l4j593pzdk7ddv50n\"},{\"key\":\"sender\",\"value\":\"cro1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8lyv94w\"},{\"key\":\"amount\",\"value\":\"1285329basecro\"},{\"key\":\"recipient\",\"value\":\"cro1htqsxfj4k9hhagtvlmqx6l4j593pzdk7ddv50n\"},{\"key\":\"sender\",\"value\":\"cro1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8lyv94w\"},{\"key\":\"amount\",\"value\":\"142814basecro\"}]},{\"type\":\"withdraw_commission\",\"attributes\":[{\"key\":\"amount\",\"value\":\"142814basecro\"}]},{\"type\":\"withdraw_rewards\",\"attributes\":[{\"key\":\"amount\",\"value\":\"1285329basecro\"},{\"key\":\"validator\",\"value\":\"crocncl1htqsxfj4k9hhagtvlmqx6l4j593pzdk7wq0ad0\"}]}]}]",
+                "info": "",
+                "gas_wanted": "200000",
+                "gas_used": "130101",
+                "events": [
+                    {
+                        "type": "tx",
+                        "attributes": [
+                            {
+                                "key": "ZmVl",
+                                "value": null,
+                                "index": true
+                            }
+                        ]
+                    },
+                    {
+                        "type": "tx",
+                        "attributes": [
+                            {
+                                "key": "YWNjX3NlcQ==",
+                                "value": "Y3JvMTQwNnkwMDluNDNhd2EwZTVuNnQydDA2YTh0dHk5YXpwdTlhdDI1LzE2",
+                                "index": true
+                            }
+                        ]
+                    },
+                    {
+                        "type": "tx",
+                        "attributes": [
+                            {
+                                "key": "c2lnbmF0dXJl",
+                                "value": "ekRqYnorSmswSDVaRlJlaHJRdTA3OHp4dzBnY0xmVHFHTTJJSGUvQkFEODc3RUc5QjA4Myt5VFUzQlpiVWYvZE5ES05YT1pOeFExcENCY1N2YzdRV0E9PQ==",
+                                "index": true
+                            }
+                        ]
+                    },
+                    {
+                        "type": "message",
+                        "attributes": [
+                            {
+                                "key": "YWN0aW9u",
+                                "value": "L2Nvc21vcy5hdXRoei52MWJldGExLk1zZ0V4ZWM=",
+                                "index": true
+                            }
+                        ]
+                    },
+                    {
+                        "type": "coin_spent",
+                        "attributes": [
+                            {
+                                "key": "c3BlbmRlcg==",
+                                "value": "Y3JvMWp2NjVzM2dycWY2djZqbDNkcDR0NmM5dDlyazk5Y2Q4bHl2OTR3",
+                                "index": true
+                            },
+                            {
+                                "key": "YW1vdW50",
+                                "value": "MTI4NTMyOWJhc2Vjcm8=",
+                                "index": true
+                            }
+                        ]
+                    },
+                    {
+                        "type": "coin_received",
+                        "attributes": [
+                            {
+                                "key": "cmVjZWl2ZXI=",
+                                "value": "Y3JvMWh0cXN4Zmo0azloaGFndHZsbXF4Nmw0ajU5M3B6ZGs3ZGR2NTBu",
+                                "index": true
+                            },
+                            {
+                                "key": "YW1vdW50",
+                                "value": "MTI4NTMyOWJhc2Vjcm8=",
+                                "index": true
+                            }
+                        ]
+                    },
+                    {
+                        "type": "transfer",
+                        "attributes": [
+                            {
+                                "key": "cmVjaXBpZW50",
+                                "value": "Y3JvMWh0cXN4Zmo0azloaGFndHZsbXF4Nmw0ajU5M3B6ZGs3ZGR2NTBu",
+                                "index": true
+                            },
+                            {
+                                "key": "c2VuZGVy",
+                                "value": "Y3JvMWp2NjVzM2dycWY2djZqbDNkcDR0NmM5dDlyazk5Y2Q4bHl2OTR3",
+                                "index": true
+                            },
+                            {
+                                "key": "YW1vdW50",
+                                "value": "MTI4NTMyOWJhc2Vjcm8=",
+                                "index": true
+                            }
+                        ]
+                    },
+                    {
+                        "type": "message",
+                        "attributes": [
+                            {
+                                "key": "c2VuZGVy",
+                                "value": "Y3JvMWp2NjVzM2dycWY2djZqbDNkcDR0NmM5dDlyazk5Y2Q4bHl2OTR3",
+                                "index": true
+                            }
+                        ]
+                    },
+                    {
+                        "type": "withdraw_rewards",
+                        "attributes": [
+                            {
+                                "key": "YW1vdW50",
+                                "value": "MTI4NTMyOWJhc2Vjcm8=",
+                                "index": true
+                            },
+                            {
+                                "key": "dmFsaWRhdG9y",
+                                "value": "Y3JvY25jbDFodHFzeGZqNGs5aGhhZ3R2bG1xeDZsNGo1OTNwemRrN3dxMGFkMA==",
+                                "index": true
+                            }
+                        ]
+                    },
+                    {
+                        "type": "message",
+                        "attributes": [
+                            {
+                                "key": "bW9kdWxl",
+                                "value": "ZGlzdHJpYnV0aW9u",
+                                "index": true
+                            },
+                            {
+                                "key": "c2VuZGVy",
+                                "value": "Y3JvMWh0cXN4Zmo0azloaGFndHZsbXF4Nmw0ajU5M3B6ZGs3ZGR2NTBu",
+                                "index": true
+                            }
+                        ]
+                    },
+                    {
+                        "type": "coin_spent",
+                        "attributes": [
+                            {
+                                "key": "c3BlbmRlcg==",
+                                "value": "Y3JvMWp2NjVzM2dycWY2djZqbDNkcDR0NmM5dDlyazk5Y2Q4bHl2OTR3",
+                                "index": true
+                            },
+                            {
+                                "key": "YW1vdW50",
+                                "value": "MTQyODE0YmFzZWNybw==",
+                                "index": true
+                            }
+                        ]
+                    },
+                    {
+                        "type": "coin_received",
+                        "attributes": [
+                            {
+                                "key": "cmVjZWl2ZXI=",
+                                "value": "Y3JvMWh0cXN4Zmo0azloaGFndHZsbXF4Nmw0ajU5M3B6ZGs3ZGR2NTBu",
+                                "index": true
+                            },
+                            {
+                                "key": "YW1vdW50",
+                                "value": "MTQyODE0YmFzZWNybw==",
+                                "index": true
+                            }
+                        ]
+                    },
+                    {
+                        "type": "transfer",
+                        "attributes": [
+                            {
+                                "key": "cmVjaXBpZW50",
+                                "value": "Y3JvMWh0cXN4Zmo0azloaGFndHZsbXF4Nmw0ajU5M3B6ZGs3ZGR2NTBu",
+                                "index": true
+                            },
+                            {
+                                "key": "c2VuZGVy",
+                                "value": "Y3JvMWp2NjVzM2dycWY2djZqbDNkcDR0NmM5dDlyazk5Y2Q4bHl2OTR3",
+                                "index": true
+                            },
+                            {
+                                "key": "YW1vdW50",
+                                "value": "MTQyODE0YmFzZWNybw==",
+                                "index": true
+                            }
+                        ]
+                    },
+                    {
+                        "type": "message",
+                        "attributes": [
+                            {
+                                "key": "c2VuZGVy",
+                                "value": "Y3JvMWp2NjVzM2dycWY2djZqbDNkcDR0NmM5dDlyazk5Y2Q4bHl2OTR3",
+                                "index": true
+                            }
+                        ]
+                    },
+                    {
+                        "type": "withdraw_commission",
+                        "attributes": [
+                            {
+                                "key": "YW1vdW50",
+                                "value": "MTQyODE0YmFzZWNybw==",
+                                "index": true
+                            }
+                        ]
+                    },
+                    {
+                        "type": "message",
+                        "attributes": [
+                            {
+                                "key": "bW9kdWxl",
+                                "value": "ZGlzdHJpYnV0aW9u",
+                                "index": true
+                            },
+                            {
+                                "key": "c2VuZGVy",
+                                "value": "Y3JvY25jbDFodHFzeGZqNGs5aGhhZ3R2bG1xeDZsNGo1OTNwemRrN3dxMGFkMA==",
+                                "index": true
+                            }
+                        ]
+                    }
+                ],
+                "codespace": ""
+            }
+        ],
+        "begin_block_events": [
+            {
+                "type": "coin_received",
+                "attributes": [
+                    {
+                        "key": "cmVjZWl2ZXI=",
+                        "value": "Y3JvMW0zaDMwd2x2c2Y4bGxydXh0cHVrZHZzeTBrbTJrdW04czIwcG0z",
+                        "index": true
+                    },
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MzQyNjliYXNlY3Jv",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "coinbase",
+                "attributes": [
+                    {
+                        "key": "bWludGVy",
+                        "value": "Y3JvMW0zaDMwd2x2c2Y4bGxydXh0cHVrZHZzeTBrbTJrdW04czIwcG0z",
+                        "index": true
+                    },
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MzQyNjliYXNlY3Jv",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "coin_spent",
+                "attributes": [
+                    {
+                        "key": "c3BlbmRlcg==",
+                        "value": "Y3JvMW0zaDMwd2x2c2Y4bGxydXh0cHVrZHZzeTBrbTJrdW04czIwcG0z",
+                        "index": true
+                    },
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MzQyNjliYXNlY3Jv",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "coin_received",
+                "attributes": [
+                    {
+                        "key": "cmVjZWl2ZXI=",
+                        "value": "Y3JvMTd4cGZ2YWttMmFtZzk2MnlsczZmODR6M2tlbGw4YzVsZ3p0ZWh2",
+                        "index": true
+                    },
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MzQyNjliYXNlY3Jv",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "transfer",
+                "attributes": [
+                    {
+                        "key": "cmVjaXBpZW50",
+                        "value": "Y3JvMTd4cGZ2YWttMmFtZzk2MnlsczZmODR6M2tlbGw4YzVsZ3p0ZWh2",
+                        "index": true
+                    },
+                    {
+                        "key": "c2VuZGVy",
+                        "value": "Y3JvMW0zaDMwd2x2c2Y4bGxydXh0cHVrZHZzeTBrbTJrdW04czIwcG0z",
+                        "index": true
+                    },
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MzQyNjliYXNlY3Jv",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "message",
+                "attributes": [
+                    {
+                        "key": "c2VuZGVy",
+                        "value": "Y3JvMW0zaDMwd2x2c2Y4bGxydXh0cHVrZHZzeTBrbTJrdW04czIwcG0z",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "mint",
+                "attributes": [
+                    {
+                        "key": "Ym9uZGVkX3JhdGlv",
+                        "value": "MC4wMDEyMDMyMjA5MDY2MTk1NzU=",
+                        "index": true
+                    },
+                    {
+                        "key": "aW5mbGF0aW9u",
+                        "value": "MC4xMzAxMjMxNzY1NDg2MjM5MDU=",
+                        "index": true
+                    },
+                    {
+                        "key": "YW5udWFsX3Byb3Zpc2lvbnM=",
+                        "value": "MjE2MjkxNDE1NTM3LjY1NDI5NDA1MTM5NTY4ODY1MA==",
+                        "index": true
+                    },
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MzQyNjk=",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "coin_spent",
+                "attributes": [
+                    {
+                        "key": "c3BlbmRlcg==",
+                        "value": "Y3JvMTd4cGZ2YWttMmFtZzk2MnlsczZmODR6M2tlbGw4YzVsZ3p0ZWh2",
+                        "index": true
+                    },
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MzQyNjliYXNlY3Jv",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "coin_received",
+                "attributes": [
+                    {
+                        "key": "cmVjZWl2ZXI=",
+                        "value": "Y3JvMWp2NjVzM2dycWY2djZqbDNkcDR0NmM5dDlyazk5Y2Q4bHl2OTR3",
+                        "index": true
+                    },
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MzQyNjliYXNlY3Jv",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "transfer",
+                "attributes": [
+                    {
+                        "key": "cmVjaXBpZW50",
+                        "value": "Y3JvMWp2NjVzM2dycWY2djZqbDNkcDR0NmM5dDlyazk5Y2Q4bHl2OTR3",
+                        "index": true
+                    },
+                    {
+                        "key": "c2VuZGVy",
+                        "value": "Y3JvMTd4cGZ2YWttMmFtZzk2MnlsczZmODR6M2tlbGw4YzVsZ3p0ZWh2",
+                        "index": true
+                    },
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MzQyNjliYXNlY3Jv",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "message",
+                "attributes": [
+                    {
+                        "key": "c2VuZGVy",
+                        "value": "Y3JvMTd4cGZ2YWttMmFtZzk2MnlsczZmODR6M2tlbGw4YzVsZ3p0ZWh2",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "proposer_reward",
+                "attributes": [
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MTcxMy40NTAwMDAwMDAwMDAwMDAwMDBiYXNlY3Jv",
+                        "index": true
+                    },
+                    {
+                        "key": "dmFsaWRhdG9y",
+                        "value": "Y3JvY25jbDFodHFzeGZqNGs5aGhhZ3R2bG1xeDZsNGo1OTNwemRrN3dxMGFkMA==",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "commission",
+                "attributes": [
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MTcxLjM0NTAwMDAwMDAwMDAwMDAwMGJhc2Vjcm8=",
+                        "index": true
+                    },
+                    {
+                        "key": "dmFsaWRhdG9y",
+                        "value": "Y3JvY25jbDFodHFzeGZqNGs5aGhhZ3R2bG1xeDZsNGo1OTNwemRrN3dxMGFkMA==",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "rewards",
+                "attributes": [
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MTcxMy40NTAwMDAwMDAwMDAwMDAwMDBiYXNlY3Jv",
+                        "index": true
+                    },
+                    {
+                        "key": "dmFsaWRhdG9y",
+                        "value": "Y3JvY25jbDFodHFzeGZqNGs5aGhhZ3R2bG1xeDZsNGo1OTNwemRrN3dxMGFkMA==",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "commission",
+                "attributes": [
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MTU5My41MDg1MDAwMDAwMDAwMDAwMDBiYXNlY3Jv",
+                        "index": true
+                    },
+                    {
+                        "key": "dmFsaWRhdG9y",
+                        "value": "Y3JvY25jbDE3Y3llNWdtZWFsbXBnejN0Y2xmamdhN3VyZGp4ajZuYWgzdTh3Mg==",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "rewards",
+                "attributes": [
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MTU5MzUuMDg1MDAwMDAwMDAwMDAwMDAwYmFzZWNybw==",
+                        "index": true
+                    },
+                    {
+                        "key": "dmFsaWRhdG9y",
+                        "value": "Y3JvY25jbDE3Y3llNWdtZWFsbXBnejN0Y2xmamdhN3VyZGp4ajZuYWgzdTh3Mg==",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "commission",
+                "attributes": [
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MTU5My41MDg1MDAwMDAwMDAwMDAwMDBiYXNlY3Jv",
+                        "index": true
+                    },
+                    {
+                        "key": "dmFsaWRhdG9y",
+                        "value": "Y3JvY25jbDFodHFzeGZqNGs5aGhhZ3R2bG1xeDZsNGo1OTNwemRrN3dxMGFkMA==",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "rewards",
+                "attributes": [
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MTU5MzUuMDg1MDAwMDAwMDAwMDAwMDAwYmFzZWNybw==",
+                        "index": true
+                    },
+                    {
+                        "key": "dmFsaWRhdG9y",
+                        "value": "Y3JvY25jbDFodHFzeGZqNGs5aGhhZ3R2bG1xeDZsNGo1OTNwemRrN3dxMGFkMA==",
+                        "index": true
+                    }
+                ]
+            }
+        ],
+        "end_block_events": null,
+        "validator_updates": null,
+        "consensus_param_updates": {
+            "block": {
+                "max_bytes": "22020096",
+                "max_gas": "-1"
+            },
+            "evidence": {
+                "max_age_num_blocks": "100000",
+                "max_age_duration": "172800000000000",
+                "max_bytes": "1048576"
+            },
+            "validator": {
+                "pub_key_types": [
+                    "ed25519"
+                ]
+            }
+        }
+    }
+}
+`

--- a/usecase/parser/test/tx_msg_exec/tx_msg_exec_mult_withdraw_delegator_reward.go
+++ b/usecase/parser/test/tx_msg_exec/tx_msg_exec_mult_withdraw_delegator_reward.go
@@ -1,0 +1,569 @@
+package usecase_parser_test
+
+const TX_MSG_EXEC_MULT_WITHDRAW_DELEGATOR_REWARD_BLOCK_RESP = `
+{
+    "jsonrpc": "2.0",
+    "id": -1,
+    "result": {
+        "block_id": {
+            "hash": "5C24ADF82FDDA56090BA29B2BCFC2599A21609DE0C04E5DC141B1A3698DBD010",
+            "parts": {
+                "total": 1,
+                "hash": "773673E2B23A74F10012F2718BFAA4A88A26B89DB9D8B472A5F8ACADF455A61C"
+            }
+        },
+        "block": {
+            "header": {
+                "version": {
+                    "block": "11"
+                },
+                "chain_id": "chaintest",
+                "height": "386",
+                "time": "2022-08-19T01:59:01.291819Z",
+                "last_block_id": {
+                    "hash": "C57A8A83A77F2B5C131ABD61F6FCAD2610EB6A6D816CA0BC9C04940DA9FC6775",
+                    "parts": {
+                        "total": 1,
+                        "hash": "C6A5AC9B3878B94C1DEB6FDCF882B2E0E2EC21CEB0958CE57251E05EDA638EDD"
+                    }
+                },
+                "last_commit_hash": "F8DEC4F3397E31FD251B2BB4D9808C47B79A48414E27B0666AB97FB409532041",
+                "data_hash": "E9D6612EAB1FC07D4EC3DBCE998796A7BA90115AAAA189FFC38A843AB1C887C8",
+                "validators_hash": "61D1EB1DA21B8A0FED97669B5E3CF6BA7EEDE24F0F5D9930F38FE472BF5638F4",
+                "next_validators_hash": "61D1EB1DA21B8A0FED97669B5E3CF6BA7EEDE24F0F5D9930F38FE472BF5638F4",
+                "consensus_hash": "048091BC7DDC283F77BFBF91D73C44DA58C3DF8A9CBC867405D8B7F3DAADA22F",
+                "app_hash": "988481D0D12CE8DBDC29AE46CD4B0882C1124BB8D356CA49441709CC34E4C444",
+                "last_results_hash": "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
+                "evidence_hash": "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
+                "proposer_address": "7BB7616678951F7A91230C2FDF5DAE8B09E5BB1E"
+            },
+            "data": {
+                "txs": [
+                    "CtYDCugBCh0vY29zbW9zLmF1dGh6LnYxYmV0YTEuTXNnRXhlYxLGAQoqY3JvMTQwNnkwMDluNDNhd2EwZTVuNnQydDA2YTh0dHk5YXpwdTlhdDI1EpcBCjcvY29zbW9zLmRpc3RyaWJ1dGlvbi52MWJldGExLk1zZ1dpdGhkcmF3RGVsZWdhdG9yUmV3YXJkElwKKmNybzFodHFzeGZqNGs5aGhhZ3R2bG1xeDZsNGo1OTNwemRrN2RkdjUwbhIuY3JvY25jbDFodHFzeGZqNGs5aGhhZ3R2bG1xeDZsNGo1OTNwemRrN3dxMGFkMAroAQodL2Nvc21vcy5hdXRoei52MWJldGExLk1zZ0V4ZWMSxgEKKmNybzE0MDZ5MDA5bjQzYXdhMGU1bjZ0MnQwNmE4dHR5OWF6cHU5YXQyNRKXAQo3L2Nvc21vcy5kaXN0cmlidXRpb24udjFiZXRhMS5Nc2dXaXRoZHJhd0RlbGVnYXRvclJld2FyZBJcCipjcm8xaHRxc3hmajRrOWhoYWd0dmxtcXg2bDRqNTkzcHpkazdkZHY1MG4SLmNyb2NuY2wxN2N5ZTVnbWVhbG1wZ3ozdGNsZmpnYTd1cmRqeGo2bmFoM3U4dzISWApQCkYKHy9jb3Ntb3MuY3J5cHRvLnNlY3AyNTZrMS5QdWJLZXkSIwohA2t8ZN3vRpAi7IJdoE5UdQ28d11h7SSsoBao8ufA15+uEgQKAggBGAMSBBDAmgwaQGgnvhOU9S+FKjkB9n3LEOTQR+F04JIvgIwSRIqZrQmyHAMyYpvl/Hgs07/jB7msvhJrcZxq5RS/C4KJSr+L4ZM="
+                ]
+            },
+            "evidence": {
+                "evidence": []
+            },
+            "last_commit": {
+                "height": "385",
+                "round": 0,
+                "block_id": {
+                    "hash": "C57A8A83A77F2B5C131ABD61F6FCAD2610EB6A6D816CA0BC9C04940DA9FC6775",
+                    "parts": {
+                        "total": 1,
+                        "hash": "C6A5AC9B3878B94C1DEB6FDCF882B2E0E2EC21CEB0958CE57251E05EDA638EDD"
+                    }
+                },
+                "signatures": [
+                    {
+                        "block_id_flag": 2,
+                        "validator_address": "4974ACEAB292467EBD9B5992E6330079F79BB1A7",
+                        "timestamp": "2022-08-19T01:59:01.291819Z",
+                        "signature": "2J/pttkZwNoakuWyux9mlfBh+Z3qK7Mv2F35kaIujYjLmVvcdWOMx62MdAvwvdQ4SaEm/J63QDqypnXSGYtrAQ=="
+                    },
+                    {
+                        "block_id_flag": 2,
+                        "validator_address": "7BB7616678951F7A91230C2FDF5DAE8B09E5BB1E",
+                        "timestamp": "2022-08-19T01:59:01.342858Z",
+                        "signature": "XHFbCn7wvequM6Wpn8+5tLUM7rid0cNXW4Rz4iLXyyGj617SmFNo0s9YRS6qBffeZjJLZEVBxV5HqzVkJmiwAg=="
+                    }
+                ]
+            }
+        }
+    }
+}
+`
+
+const TX_MSG_EXEC_MULT_WITHDRAW_DELEGATOR_REWARD_RESULTS_RESP = `
+{
+    "jsonrpc": "2.0",
+    "id": -1,
+    "result": {
+        "height": "386",
+        "txs_results": [
+            {
+                "code": 0,
+                "data": "CiMKHS9jb3Ntb3MuYXV0aHoudjFiZXRhMS5Nc2dFeGVjEgIKAAojCh0vY29zbW9zLmF1dGh6LnYxYmV0YTEuTXNnRXhlYxICCgA=",
+                "log": "[{\"events\":[{\"type\":\"coin_received\",\"attributes\":[{\"key\":\"receiver\",\"value\":\"cro1htqsxfj4k9hhagtvlmqx6l4j593pzdk7ddv50n\"},{\"key\":\"amount\",\"value\":\"513305basecro\"}]},{\"type\":\"coin_spent\",\"attributes\":[{\"key\":\"spender\",\"value\":\"cro1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8lyv94w\"},{\"key\":\"amount\",\"value\":\"513305basecro\"}]},{\"type\":\"message\",\"attributes\":[{\"key\":\"action\",\"value\":\"/cosmos.authz.v1beta1.MsgExec\"},{\"key\":\"sender\",\"value\":\"cro1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8lyv94w\"},{\"key\":\"module\",\"value\":\"distribution\"},{\"key\":\"sender\",\"value\":\"cro1htqsxfj4k9hhagtvlmqx6l4j593pzdk7ddv50n\"}]},{\"type\":\"transfer\",\"attributes\":[{\"key\":\"recipient\",\"value\":\"cro1htqsxfj4k9hhagtvlmqx6l4j593pzdk7ddv50n\"},{\"key\":\"sender\",\"value\":\"cro1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8lyv94w\"},{\"key\":\"amount\",\"value\":\"513305basecro\"}]},{\"type\":\"withdraw_rewards\",\"attributes\":[{\"key\":\"amount\",\"value\":\"513305basecro\"},{\"key\":\"validator\",\"value\":\"crocncl1htqsxfj4k9hhagtvlmqx6l4j593pzdk7wq0ad0\"}]}]},{\"msg_index\":1,\"events\":[{\"type\":\"message\",\"attributes\":[{\"key\":\"action\",\"value\":\"/cosmos.authz.v1beta1.MsgExec\"},{\"key\":\"module\",\"value\":\"distribution\"},{\"key\":\"sender\",\"value\":\"cro1htqsxfj4k9hhagtvlmqx6l4j593pzdk7ddv50n\"}]},{\"type\":\"withdraw_rewards\",\"attributes\":[{\"key\":\"amount\"},{\"key\":\"validator\",\"value\":\"crocncl17cye5gmealmpgz3tclfjga7urdjxj6nah3u8w2\"}]}]}]",
+                "info": "",
+                "gas_wanted": "200000",
+                "gas_used": "157871",
+                "events": [
+                    {
+                        "type": "tx",
+                        "attributes": [
+                            {
+                                "key": "ZmVl",
+                                "value": null,
+                                "index": true
+                            }
+                        ]
+                    },
+                    {
+                        "type": "tx",
+                        "attributes": [
+                            {
+                                "key": "YWNjX3NlcQ==",
+                                "value": "Y3JvMTQwNnkwMDluNDNhd2EwZTVuNnQydDA2YTh0dHk5YXpwdTlhdDI1LzM=",
+                                "index": true
+                            }
+                        ]
+                    },
+                    {
+                        "type": "tx",
+                        "attributes": [
+                            {
+                                "key": "c2lnbmF0dXJl",
+                                "value": "YUNlK0U1VDFMNFVxT1FIMmZjc1E1TkJINFhUZ2tpK0FqQkpFaXBtdENiSWNBekppbStYOGVDelR2K01IdWF5K0VtdHhuR3JsRkw4TGdvbEt2NHZoa3c9PQ==",
+                                "index": true
+                            }
+                        ]
+                    },
+                    {
+                        "type": "message",
+                        "attributes": [
+                            {
+                                "key": "YWN0aW9u",
+                                "value": "L2Nvc21vcy5hdXRoei52MWJldGExLk1zZ0V4ZWM=",
+                                "index": true
+                            }
+                        ]
+                    },
+                    {
+                        "type": "coin_spent",
+                        "attributes": [
+                            {
+                                "key": "c3BlbmRlcg==",
+                                "value": "Y3JvMWp2NjVzM2dycWY2djZqbDNkcDR0NmM5dDlyazk5Y2Q4bHl2OTR3",
+                                "index": true
+                            },
+                            {
+                                "key": "YW1vdW50",
+                                "value": "NTEzMzA1YmFzZWNybw==",
+                                "index": true
+                            }
+                        ]
+                    },
+                    {
+                        "type": "coin_received",
+                        "attributes": [
+                            {
+                                "key": "cmVjZWl2ZXI=",
+                                "value": "Y3JvMWh0cXN4Zmo0azloaGFndHZsbXF4Nmw0ajU5M3B6ZGs3ZGR2NTBu",
+                                "index": true
+                            },
+                            {
+                                "key": "YW1vdW50",
+                                "value": "NTEzMzA1YmFzZWNybw==",
+                                "index": true
+                            }
+                        ]
+                    },
+                    {
+                        "type": "transfer",
+                        "attributes": [
+                            {
+                                "key": "cmVjaXBpZW50",
+                                "value": "Y3JvMWh0cXN4Zmo0azloaGFndHZsbXF4Nmw0ajU5M3B6ZGs3ZGR2NTBu",
+                                "index": true
+                            },
+                            {
+                                "key": "c2VuZGVy",
+                                "value": "Y3JvMWp2NjVzM2dycWY2djZqbDNkcDR0NmM5dDlyazk5Y2Q4bHl2OTR3",
+                                "index": true
+                            },
+                            {
+                                "key": "YW1vdW50",
+                                "value": "NTEzMzA1YmFzZWNybw==",
+                                "index": true
+                            }
+                        ]
+                    },
+                    {
+                        "type": "message",
+                        "attributes": [
+                            {
+                                "key": "c2VuZGVy",
+                                "value": "Y3JvMWp2NjVzM2dycWY2djZqbDNkcDR0NmM5dDlyazk5Y2Q4bHl2OTR3",
+                                "index": true
+                            }
+                        ]
+                    },
+                    {
+                        "type": "withdraw_rewards",
+                        "attributes": [
+                            {
+                                "key": "YW1vdW50",
+                                "value": "NTEzMzA1YmFzZWNybw==",
+                                "index": true
+                            },
+                            {
+                                "key": "dmFsaWRhdG9y",
+                                "value": "Y3JvY25jbDFodHFzeGZqNGs5aGhhZ3R2bG1xeDZsNGo1OTNwemRrN3dxMGFkMA==",
+                                "index": true
+                            }
+                        ]
+                    },
+                    {
+                        "type": "message",
+                        "attributes": [
+                            {
+                                "key": "bW9kdWxl",
+                                "value": "ZGlzdHJpYnV0aW9u",
+                                "index": true
+                            },
+                            {
+                                "key": "c2VuZGVy",
+                                "value": "Y3JvMWh0cXN4Zmo0azloaGFndHZsbXF4Nmw0ajU5M3B6ZGs3ZGR2NTBu",
+                                "index": true
+                            }
+                        ]
+                    },
+                    {
+                        "type": "message",
+                        "attributes": [
+                            {
+                                "key": "YWN0aW9u",
+                                "value": "L2Nvc21vcy5hdXRoei52MWJldGExLk1zZ0V4ZWM=",
+                                "index": true
+                            }
+                        ]
+                    },
+                    {
+                        "type": "withdraw_rewards",
+                        "attributes": [
+                            {
+                                "key": "YW1vdW50",
+                                "value": null,
+                                "index": true
+                            },
+                            {
+                                "key": "dmFsaWRhdG9y",
+                                "value": "Y3JvY25jbDE3Y3llNWdtZWFsbXBnejN0Y2xmamdhN3VyZGp4ajZuYWgzdTh3Mg==",
+                                "index": true
+                            }
+                        ]
+                    },
+                    {
+                        "type": "message",
+                        "attributes": [
+                            {
+                                "key": "bW9kdWxl",
+                                "value": "ZGlzdHJpYnV0aW9u",
+                                "index": true
+                            },
+                            {
+                                "key": "c2VuZGVy",
+                                "value": "Y3JvMWh0cXN4Zmo0azloaGFndHZsbXF4Nmw0ajU5M3B6ZGs3ZGR2NTBu",
+                                "index": true
+                            }
+                        ]
+                    }
+                ],
+                "codespace": ""
+            }
+        ],
+        "begin_block_events": [
+            {
+                "type": "coin_received",
+                "attributes": [
+                    {
+                        "key": "cmVjZWl2ZXI=",
+                        "value": "Y3JvMW0zaDMwd2x2c2Y4bGxydXh0cHVrZHZzeTBrbTJrdW04czIwcG0z",
+                        "index": true
+                    },
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MzQyMzViYXNlY3Jv",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "coinbase",
+                "attributes": [
+                    {
+                        "key": "bWludGVy",
+                        "value": "Y3JvMW0zaDMwd2x2c2Y4bGxydXh0cHVrZHZzeTBrbTJrdW04czIwcG0z",
+                        "index": true
+                    },
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MzQyMzViYXNlY3Jv",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "coin_spent",
+                "attributes": [
+                    {
+                        "key": "c3BlbmRlcg==",
+                        "value": "Y3JvMW0zaDMwd2x2c2Y4bGxydXh0cHVrZHZzeTBrbTJrdW04czIwcG0z",
+                        "index": true
+                    },
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MzQyMzViYXNlY3Jv",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "coin_received",
+                "attributes": [
+                    {
+                        "key": "cmVjZWl2ZXI=",
+                        "value": "Y3JvMTd4cGZ2YWttMmFtZzk2MnlsczZmODR6M2tlbGw4YzVsZ3p0ZWh2",
+                        "index": true
+                    },
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MzQyMzViYXNlY3Jv",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "transfer",
+                "attributes": [
+                    {
+                        "key": "cmVjaXBpZW50",
+                        "value": "Y3JvMTd4cGZ2YWttMmFtZzk2MnlsczZmODR6M2tlbGw4YzVsZ3p0ZWh2",
+                        "index": true
+                    },
+                    {
+                        "key": "c2VuZGVy",
+                        "value": "Y3JvMW0zaDMwd2x2c2Y4bGxydXh0cHVrZHZzeTBrbTJrdW04czIwcG0z",
+                        "index": true
+                    },
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MzQyMzViYXNlY3Jv",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "message",
+                "attributes": [
+                    {
+                        "key": "c2VuZGVy",
+                        "value": "Y3JvMW0zaDMwd2x2c2Y4bGxydXh0cHVrZHZzeTBrbTJrdW04czIwcG0z",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "mint",
+                "attributes": [
+                    {
+                        "key": "Ym9uZGVkX3JhdGlv",
+                        "value": "MC4wMDEyMDMzNTk5NTc4NDg2MTI=",
+                        "index": true
+                    },
+                    {
+                        "key": "aW5mbGF0aW9u",
+                        "value": "MC4xMzAwMDc5MzYyNjE1MzA0NzI=",
+                        "index": true
+                    },
+                    {
+                        "key": "YW5udWFsX3Byb3Zpc2lvbnM=",
+                        "value": "MjE2MDc0OTAzNTQ2LjU2MjA2MzU0NTkzMDE3MDMyMA==",
+                        "index": true
+                    },
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MzQyMzU=",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "coin_spent",
+                "attributes": [
+                    {
+                        "key": "c3BlbmRlcg==",
+                        "value": "Y3JvMTd4cGZ2YWttMmFtZzk2MnlsczZmODR6M2tlbGw4YzVsZ3p0ZWh2",
+                        "index": true
+                    },
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MzQyMzViYXNlY3Jv",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "coin_received",
+                "attributes": [
+                    {
+                        "key": "cmVjZWl2ZXI=",
+                        "value": "Y3JvMWp2NjVzM2dycWY2djZqbDNkcDR0NmM5dDlyazk5Y2Q4bHl2OTR3",
+                        "index": true
+                    },
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MzQyMzViYXNlY3Jv",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "transfer",
+                "attributes": [
+                    {
+                        "key": "cmVjaXBpZW50",
+                        "value": "Y3JvMWp2NjVzM2dycWY2djZqbDNkcDR0NmM5dDlyazk5Y2Q4bHl2OTR3",
+                        "index": true
+                    },
+                    {
+                        "key": "c2VuZGVy",
+                        "value": "Y3JvMTd4cGZ2YWttMmFtZzk2MnlsczZmODR6M2tlbGw4YzVsZ3p0ZWh2",
+                        "index": true
+                    },
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MzQyMzViYXNlY3Jv",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "message",
+                "attributes": [
+                    {
+                        "key": "c2VuZGVy",
+                        "value": "Y3JvMTd4cGZ2YWttMmFtZzk2MnlsczZmODR6M2tlbGw4YzVsZ3p0ZWh2",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "proposer_reward",
+                "attributes": [
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MTcxMS43NTAwMDAwMDAwMDAwMDAwMDBiYXNlY3Jv",
+                        "index": true
+                    },
+                    {
+                        "key": "dmFsaWRhdG9y",
+                        "value": "Y3JvY25jbDE3Y3llNWdtZWFsbXBnejN0Y2xmamdhN3VyZGp4ajZuYWgzdTh3Mg==",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "commission",
+                "attributes": [
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MTcxLjE3NTAwMDAwMDAwMDAwMDAwMGJhc2Vjcm8=",
+                        "index": true
+                    },
+                    {
+                        "key": "dmFsaWRhdG9y",
+                        "value": "Y3JvY25jbDE3Y3llNWdtZWFsbXBnejN0Y2xmamdhN3VyZGp4ajZuYWgzdTh3Mg==",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "rewards",
+                "attributes": [
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MTcxMS43NTAwMDAwMDAwMDAwMDAwMDBiYXNlY3Jv",
+                        "index": true
+                    },
+                    {
+                        "key": "dmFsaWRhdG9y",
+                        "value": "Y3JvY25jbDE3Y3llNWdtZWFsbXBnejN0Y2xmamdhN3VyZGp4ajZuYWgzdTh3Mg==",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "commission",
+                "attributes": [
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MTU5MS45Mjc1MDAwMDAwMDAwMDAwMDBiYXNlY3Jv",
+                        "index": true
+                    },
+                    {
+                        "key": "dmFsaWRhdG9y",
+                        "value": "Y3JvY25jbDE3Y3llNWdtZWFsbXBnejN0Y2xmamdhN3VyZGp4ajZuYWgzdTh3Mg==",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "rewards",
+                "attributes": [
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MTU5MTkuMjc1MDAwMDAwMDAwMDAwMDAwYmFzZWNybw==",
+                        "index": true
+                    },
+                    {
+                        "key": "dmFsaWRhdG9y",
+                        "value": "Y3JvY25jbDE3Y3llNWdtZWFsbXBnejN0Y2xmamdhN3VyZGp4ajZuYWgzdTh3Mg==",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "commission",
+                "attributes": [
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MTU5MS45Mjc1MDAwMDAwMDAwMDAwMDBiYXNlY3Jv",
+                        "index": true
+                    },
+                    {
+                        "key": "dmFsaWRhdG9y",
+                        "value": "Y3JvY25jbDFodHFzeGZqNGs5aGhhZ3R2bG1xeDZsNGo1OTNwemRrN3dxMGFkMA==",
+                        "index": true
+                    }
+                ]
+            },
+            {
+                "type": "rewards",
+                "attributes": [
+                    {
+                        "key": "YW1vdW50",
+                        "value": "MTU5MTkuMjc1MDAwMDAwMDAwMDAwMDAwYmFzZWNybw==",
+                        "index": true
+                    },
+                    {
+                        "key": "dmFsaWRhdG9y",
+                        "value": "Y3JvY25jbDFodHFzeGZqNGs5aGhhZ3R2bG1xeDZsNGo1OTNwemRrN3dxMGFkMA==",
+                        "index": true
+                    }
+                ]
+            }
+        ],
+        "end_block_events": null,
+        "validator_updates": null,
+        "consensus_param_updates": {
+            "block": {
+                "max_bytes": "22020096",
+                "max_gas": "-1"
+            },
+            "evidence": {
+                "max_age_num_blocks": "100000",
+                "max_age_duration": "172800000000000",
+                "max_bytes": "1048576"
+            },
+            "validator": {
+                "pub_key_types": [
+                    "ed25519"
+                ]
+            }
+        }
+    }
+}
+`

--- a/usecase/parser/utils/txs_results_event.go
+++ b/usecase/parser/utils/txs_results_event.go
@@ -61,3 +61,14 @@ func (log *ParsedTxsResultsEvents) GetEventsByType(t string) []*ParsedTxsResultL
 
 	return logEvents
 }
+
+func (log *ParsedTxsResultsEvents) GetRawEvents() []model.BlockResultsEvent {
+	return log.rawEvents
+}
+
+func (log *ParsedTxsResultsEvents) GetTypeIndex(key string) []int {
+	return log.typeIndex[key]
+}
+func (log *ParsedTxsResultsEvents) RemoveIndexType(key string, index int) {
+	log.typeIndex[key] = append(log.typeIndex[key][:index], log.typeIndex[key][index+1:]...)
+}

--- a/usecase/parser/utils/txs_results_log_event.go
+++ b/usecase/parser/utils/txs_results_log_event.go
@@ -80,3 +80,10 @@ func (log *ParsedTxsResultLogEvent) GetAttributeByKey(key string) *string {
 	}
 	return &log.rawEvent.Attributes[log.keyIndex[key]].Value
 }
+
+func (log *ParsedTxsResultLogEvent) GetRawEvents() model.BlockResultsEvent {
+	return log.rawEvent
+}
+func (log *ParsedTxsResultLogEvent) GetKeyIndex() map[string]int {
+	return log.keyIndex
+}


### PR DESCRIPTION
Support inner msg type:
* MsgSend
* MsgSetWithdrawAddress
* MsgWithdrawDelegatorReward
* MsgWithdrawValidatorCommission
* MsgFundCommunityPool
Solution: Found that the TxsResult.Events order is following the events emit order. The inner msg parser groups the event by message @type with first in, first out method. In CosmosSDK, the /keeper/msg_server.go of each module shows the event emit order.