### PR TITLE
Fix: resolve duplicate NFT tokens with upsert

### DIFF
--- a/projection/nft/migrations/20221101171151_alter_view_nft_tokens_drop_constraint.down.sql
+++ b/projection/nft/migrations/20221101171151_alter_view_nft_tokens_drop_constraint.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE view_nft_tokens ADD CONSTRAINT view_nft_tokens_denom_id_token_id_key UNIQUE (denom_id, token_id);
+
+DROP INDEX if exists view_nft_tokens_denom_id_btree_index;

--- a/projection/nft/migrations/20221101171151_alter_view_nft_tokens_drop_constraint.down.sql
+++ b/projection/nft/migrations/20221101171151_alter_view_nft_tokens_drop_constraint.down.sql
@@ -1,3 +1,3 @@
 ALTER TABLE view_nft_tokens ADD CONSTRAINT view_nft_tokens_denom_id_token_id_key UNIQUE (denom_id, token_id);
 
-DROP INDEX if exists view_nft_tokens_denom_id_btree_index;
+DROP INDEX if exists view_nft_tokens_denom_id_token_id_btree_index;

--- a/projection/nft/migrations/20221101171151_alter_view_nft_tokens_drop_constraint.down.sql
+++ b/projection/nft/migrations/20221101171151_alter_view_nft_tokens_drop_constraint.down.sql
@@ -1,3 +1,1 @@
-ALTER TABLE view_nft_tokens ADD CONSTRAINT view_nft_tokens_ids_btree_index UNIQUE (denom_id, token_id);
-
-DROP INDEX if exists view_nft_tokens_denom_id_token_id_btree_index;
+ALTER TABLE view_nft_tokens ADD CONSTRAINT view_nft_tokens_denom_id_token_id_key UNIQUE (denom_id, token_id);

--- a/projection/nft/migrations/20221101171151_alter_view_nft_tokens_drop_constraint.down.sql
+++ b/projection/nft/migrations/20221101171151_alter_view_nft_tokens_drop_constraint.down.sql
@@ -1,3 +1,3 @@
-ALTER TABLE view_nft_tokens ADD CONSTRAINT view_nft_tokens_denom_id_token_id_key UNIQUE (denom_id, token_id);
+ALTER TABLE view_nft_tokens ADD CONSTRAINT view_nft_tokens_ids_btree_index UNIQUE (denom_id, token_id);
 
 DROP INDEX if exists view_nft_tokens_denom_id_token_id_btree_index;

--- a/projection/nft/migrations/20221101171151_alter_view_nft_tokens_drop_constraint.up.sql
+++ b/projection/nft/migrations/20221101171151_alter_view_nft_tokens_drop_constraint.up.sql
@@ -1,3 +1,1 @@
-ALTER TABLE view_nft_tokens DROP CONSTRAINT view_nft_tokens_ids_btree_index;
-
-CREATE INDEX view_nft_tokens_denom_id_token_id_btree_index ON view_nft_tokens USING btree (denom_id, token_id);
+ALTER TABLE view_nft_tokens DROP CONSTRAINT view_nft_tokens_denom_id_token_id_key;

--- a/projection/nft/migrations/20221101171151_alter_view_nft_tokens_drop_constraint.up.sql
+++ b/projection/nft/migrations/20221101171151_alter_view_nft_tokens_drop_constraint.up.sql
@@ -1,3 +1,3 @@
 ALTER TABLE view_nft_tokens DROP CONSTRAINT view_nft_tokens_denom_id_token_id_key;
 
-CREATE UNIQUE INDEX view_nft_tokens_denom_id_token_id_btree_index ON view_nft_tokens USING btree (denom_id, token_id);
+CREATE INDEX view_nft_tokens_denom_id_token_id_btree_index ON view_nft_tokens USING btree (denom_id, token_id);

--- a/projection/nft/migrations/20221101171151_alter_view_nft_tokens_drop_constraint.up.sql
+++ b/projection/nft/migrations/20221101171151_alter_view_nft_tokens_drop_constraint.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE view_nft_tokens DROP CONSTRAINT view_nft_tokens_denom_id_token_id_key;
+
+CREATE UNIQUE INDEX view_nft_tokens_denom_id_btree_index ON view_nft_tokens USING btree (denom_id);

--- a/projection/nft/migrations/20221101171151_alter_view_nft_tokens_drop_constraint.up.sql
+++ b/projection/nft/migrations/20221101171151_alter_view_nft_tokens_drop_constraint.up.sql
@@ -1,3 +1,3 @@
-ALTER TABLE view_nft_tokens DROP CONSTRAINT view_nft_tokens_denom_id_token_id_key;
+ALTER TABLE view_nft_tokens DROP CONSTRAINT view_nft_tokens_ids_btree_index;
 
 CREATE INDEX view_nft_tokens_denom_id_token_id_btree_index ON view_nft_tokens USING btree (denom_id, token_id);

--- a/projection/nft/migrations/20221101171151_alter_view_nft_tokens_drop_constraint.up.sql
+++ b/projection/nft/migrations/20221101171151_alter_view_nft_tokens_drop_constraint.up.sql
@@ -1,3 +1,3 @@
 ALTER TABLE view_nft_tokens DROP CONSTRAINT view_nft_tokens_denom_id_token_id_key;
 
-CREATE UNIQUE INDEX view_nft_tokens_denom_id_btree_index ON view_nft_tokens USING btree (denom_id);
+CREATE UNIQUE INDEX view_nft_tokens_denom_id_token_id_btree_index ON view_nft_tokens USING btree (denom_id, token_id);


### PR DESCRIPTION
The same `denom_id` and `token_id`on burned NFT will be used for minting a new NFT. To avoid the database unique key conflict, we use `upsert` NFT token ( update with condition `burned = true`) instead of `insert` on `MsgNFTMintNFT` event.