### PR TITLE
Problem: duplicate attribute key on IBC MsgAcknowledgement

### DIFF
--- a/usecase/parser/ibcmsg/ibcmsg.go
+++ b/usecase/parser/ibcmsg/ibcmsg.go
@@ -784,7 +784,7 @@ func ParseMsgRecvPacket(
 	rawPacketData, err := base64_internal.DecodeString(rawMsg.Packet.Data)
 	if err != nil {
 		rawFungibleTokenPacketData = ibc_model.FungibleTokenPacketData{}
-	} else  {
+	} else {
 		if err := json.Unmarshal(rawPacketData, &rawFungibleTokenPacketData); err != nil {
 			rawFungibleTokenPacketData = ibc_model.FungibleTokenPacketData{}
 		}
@@ -907,7 +907,7 @@ func ParseMsgAcknowledgement(
 	rawPacketData, err := base64_internal.DecodeString(rawMsg.Packet.Data)
 	if err != nil {
 		rawFungibleTokenPacketData = ibc_model.FungibleTokenPacketData{}
-	} else  {
+	} else {
 		if err := json.Unmarshal(rawPacketData, &rawFungibleTokenPacketData); err != nil {
 			rawFungibleTokenPacketData = ibc_model.FungibleTokenPacketData{}
 		}
@@ -940,20 +940,20 @@ func ParseMsgAcknowledgement(
 
 	acknowledgePacketEvents := log.GetEventsByType("acknowledge_packet")
 
-	var packetSequence  uint64
-	var channelOrdering  string
-	var connectionID  string
+	var packetSequence uint64
+	var channelOrdering string
+	var connectionID string
 	for _, acknowledgePacketEvent := range acknowledgePacketEvents {
 		if acknowledgePacketEvent.HasAttribute("packet_sequence") {
-			packetSequence =  typeconv.MustAtou64(acknowledgePacketEvent.MustGetAttributeByKey("packet_sequence"))
+			packetSequence = typeconv.MustAtou64(acknowledgePacketEvent.MustGetAttributeByKey("packet_sequence"))
 		}
 		if acknowledgePacketEvent.HasAttribute("packet_channel_ordering") {
 			channelOrdering = acknowledgePacketEvent.MustGetAttributeByKey("packet_channel_ordering")
 		}
 		if acknowledgePacketEvent.HasAttribute("packet_connection") {
-			connectionID=    acknowledgePacketEvent.MustGetAttributeByKey("packet_connection")
+			connectionID = acknowledgePacketEvent.MustGetAttributeByKey("packet_connection")
 		}
-	
+
 	}
 
 	fungibleTokenPacketEvents := log.GetEventsByType("fungible_token_packet")

--- a/usecase/parser/ibcmsg/ibcmsg.go
+++ b/usecase/parser/ibcmsg/ibcmsg.go
@@ -938,9 +938,22 @@ func ParseMsgAcknowledgement(
 
 	log := utils.NewParsedTxsResultLog(&parserParams.TxsResult.Log[parserParams.MsgIndex])
 
-	acknowledgePacketEvent := log.GetEventByType("acknowledge_packet")
-	if acknowledgePacketEvent == nil {
-		panic("missing `acknowledge_packet` event in TxsResult log")
+	acknowledgePacketEvents := log.GetEventsByType("acknowledge_packet")
+
+	var packetSequence  uint64
+	var channelOrdering  string
+	var connectionID  string
+	for _, acknowledgePacketEvent := range acknowledgePacketEvents {
+		if acknowledgePacketEvent.HasAttribute("packet_sequence") {
+			packetSequence =  typeconv.MustAtou64(acknowledgePacketEvent.MustGetAttributeByKey("packet_sequence"))
+		}
+		if acknowledgePacketEvent.HasAttribute("packet_channel_ordering") {
+			channelOrdering = acknowledgePacketEvent.MustGetAttributeByKey("packet_channel_ordering")
+		}
+		if acknowledgePacketEvent.HasAttribute("packet_connection") {
+			connectionID=    acknowledgePacketEvent.MustGetAttributeByKey("packet_connection")
+		}
+	
 	}
 
 	fungibleTokenPacketEvents := log.GetEventsByType("fungible_token_packet")
@@ -954,9 +967,9 @@ func ParseMsgAcknowledgement(
 				FungibleTokenPacketData: rawFungibleTokenPacketData,
 			},
 
-			PacketSequence:  typeconv.MustAtou64(acknowledgePacketEvent.MustGetAttributeByKey("packet_sequence")),
-			ChannelOrdering: acknowledgePacketEvent.MustGetAttributeByKey("packet_channel_ordering"),
-			ConnectionID:    acknowledgePacketEvent.MustGetAttributeByKey("packet_connection"),
+			PacketSequence:  packetSequence,
+			ChannelOrdering: channelOrdering,
+			ConnectionID:    connectionID,
 		}
 
 		// Getting possible signer address from Msg
@@ -1002,9 +1015,9 @@ func ParseMsgAcknowledgement(
 			MaybeError: maybeErr,
 		},
 
-		PacketSequence:  typeconv.MustAtou64(acknowledgePacketEvent.MustGetAttributeByKey("packet_sequence")),
-		ChannelOrdering: acknowledgePacketEvent.MustGetAttributeByKey("packet_channel_ordering"),
-		ConnectionID:    acknowledgePacketEvent.MustGetAttributeByKey("packet_connection"),
+		PacketSequence:  packetSequence,
+		ChannelOrdering: channelOrdering,
+		ConnectionID:    connectionID,
 	}
 
 	// Getting possible signer address from Msg

--- a/usecase/parser/utils/txs_results_log_event.go
+++ b/usecase/parser/utils/txs_results_log_event.go
@@ -23,7 +23,7 @@ func NewParsedTxsResultLogEvent(rawEvent *model.BlockResultsEvent) *ParsedTxsRes
 
 	for i, attribute := range rawEvent.Attributes {
 		if event.HasAttribute(attribute.Key) {
-			panic(fmt.Sprintf("duplciated attribute key `%s`", attribute.Key))
+			panic(fmt.Sprintf("duplicated attribute key `%s`", attribute.Key))
 		}
 		event.keyIndex[attribute.Key] = i
 	}


### PR DESCRIPTION
Since the events in `MsgAcknowledgement` in type `acknowledge_packet` are duplicated, the code will get the last events.

Example:
```
 {
                "type": "send_packet",
                "attributes": [
                    {
                        "key": "packet_data",
                        "value": "{"amount":"4975060000","denom":"transfer/channel-0/basetcro","receiver":"tcro1q3aradsw9nldnnkna42dfmtakg8hxdcuvz7zhe","sender":"tcrc1k480peuqy544gcfqd0rnaxq7g002633j2rk8cj"}"
                    },
                    {
                        "key": "packet_data_hex",
                        "value": "7b22616d6f756e74223a2234393735303630303030222c2264656e6f6d223a227472616e736665722f6368616e6e656c2d302f626173657463726f222c227265636569766572223a227463726f317133617261647377396e6c646e6e6b6e61343264666d74616b67386878646375767a377a6865222c2273656e646572223a2274637263316b3438307065757179353434676366716430726e61787137673030323633336a32726b38636a227d"
                    },
                    {
                        "key": "packet_timeout_height",
                        "value": "0-0"
                    },
                    {
                        "key": "packet_timeout_timestamp",
                        "value": "1668099806572469970"
                    },
                    {
                        "key": "packet_sequence",
                        "value": "714"
                    },
                    {
                        "key": "packet_src_port",
                        "value": "transfer"
                    },
                    {
                        "key": "packet_src_channel",
                        "value": "channel-0"
                    },
                    {
                        "key": "packet_dst_port",
                        "value": "transfer"
                    },
                    {
                        "key": "packet_dst_channel",
                        "value": "channel-131"
                    },
                    {
                        "key": "packet_channel_ordering",
                        "value": "ORDER_UNORDERED"
                    },
                    {
                        "key": "packet_connection",
                        "value": "connection-0"
                    },
                    
                    
                   // Get the events below only 
                    {
                        "key": "packet_data",
                        "value": "{"amount":"4975060000","denom":"transfer/channel-0/basetcro","receiver":"tcro1q3aradsw9nldnnkna42dfmtakg8hxdcuvz7zhe","sender":"tcrc1k480peuqy544gcfqd0rnaxq7g002633j2rk8cj"}"
                    },
                    {
                        "key": "packet_data_hex",
                        "value": "7b22616d6f756e74223a2234393735303630303030222c2264656e6f6d223a227472616e736665722f6368616e6e656c2d302f626173657463726f222c227265636569766572223a227463726f317133617261647377396e6c646e6e6b6e61343264666d74616b67386878646375767a377a6865222c2273656e646572223a2274637263316b3438307065757179353434676366716430726e61787137673030323633336a32726b38636a227d"
                    },
                    {
                        "key": "packet_timeout_height",
                        "value": "0-0"
                    },
                    {
                        "key": "packet_timeout_timestamp",
                        "value": "1668099806572469970"
                    },
                    {
                        "key": "packet_sequence",
                        "value": "714"
                    },
                    {
                        "key": "packet_src_port",
                        "value": "transfer"
                    },
                    {
                        "key": "packet_src_channel",
                        "value": "channel-0"
                    },
                    {
                        "key": "packet_dst_port",
                        "value": "transfer"
                    },
                    {
                        "key": "packet_dst_channel",
                        "value": "channel-131"
                    },
                    {
                        "key": "packet_channel_ordering",
                        "value": "ORDER_UNORDERED"
                    },
                    {
                        "key": "packet_connection",
                        "value": "connection-0"
                    }
                ]
            }
```


