### PR TITLE
Fix: Return empty command instead of panic for empty ibc timeout_packet

### DIFF
--- a/usecase/parser/ibc/msg.go
+++ b/usecase/parser/ibc/msg.go
@@ -1137,7 +1137,8 @@ func ParseMsgTimeout(
 
 	timeoutPacketEvent := log.GetEventByType("timeout_packet")
 	if timeoutPacketEvent == nil {
-		panic("missing `timeout_packet` event in TxsResult log")
+		parserParams.Logger.Errorf("missing `timeout_packet` event in TxsResult log: ", parserParams.MsgCommonParams.TxHash)
+		return []command.Command{}, []string{}
 	}
 
 	msgTimeoutParams := ibc_model.MsgTimeoutParams{

--- a/usecase/parser/ibc/msg.go
+++ b/usecase/parser/ibc/msg.go
@@ -1137,7 +1137,7 @@ func ParseMsgTimeout(
 
 	timeoutPacketEvent := log.GetEventByType("timeout_packet")
 	if timeoutPacketEvent == nil {
-		parserParams.Logger.Errorf("missing `timeout_packet` event in TxsResult log: ", parserParams.MsgCommonParams.TxHash)
+		parserParams.Logger.Warnf("missing `timeout_packet` event in TxsResult log: ", parserParams.MsgCommonParams.TxHash)
 		return []command.Command{}, []string{}
 	}
 


### PR DESCRIPTION
### Issue:
`panic: panic when parsing block at height 13123448: missing `timeout_packet` event in TxsResult log`

Got empty `timeout_packet` in `msg_index=1` log
https://rest.mainnet.crypto.org/cosmos/tx/v1beta1/txs/1865B4678750DD77E1834BA78A5FCAE4D827B91DA101C4BBB6492793038D4CA7

IBC transfer refunded in [DD7E643082DC29337CFC09D033A509D1EF4D0693DFD0C483CE4D1C0147B00A60](https://www.mintscan.io/crypto-org/transactions/DD7E643082DC29337CFC09D033A509D1EF4D0693DFD0C483CE4D1C0147B00A60)

but show in [1865B4678750DD77E1834BA78A5FCAE4D827B91DA101C4BBB6492793038D4CA7](https://www.mintscan.io/crypto-org/transactions/1865B4678750DD77E1834BA78A5FCAE4D827B91DA101C4BBB6492793038D4CA7) too with empty `timeout_packet`


The refund data
```
{
  "amount": "300000000",
  "denom": "basecro",
  "receiver": "umee163ndtplrrpkh2faf2c0y6t9v86llx86qqa0dul",
  "sender": "cro163ndtplrrpkh2faf2c0y6t9v86llx86q2s6tyu"
}
```

### Solution:
Skip the extra IBC timeout message
