### PR TITLE
Chain Indexing: parse IBC and ICA message on EVM transaction

### DIFF
--- a/usecase/parser/icaauth/msg.go
+++ b/usecase/parser/icaauth/msg.go
@@ -311,7 +311,7 @@ func ParseMsgRegisterAccount(
 
 	log := utils.NewParsedTxsResultLog(&parserParams.TxsResult.Log[parserParams.MsgIndex])
 
-	if parserParams.IsEvmInnerMsg {
+	if parserParams.IsEthereumTxInnerMsg {
 		var commands []command.Command
 		var possibleSignerAddresses []string
 

--- a/usecase/parser/icaauth/msg.go
+++ b/usecase/parser/icaauth/msg.go
@@ -310,6 +310,53 @@ func ParseMsgRegisterAccount(
 	}
 
 	log := utils.NewParsedTxsResultLog(&parserParams.TxsResult.Log[parserParams.MsgIndex])
+
+	if parserParams.IsEvmInnerMsg {
+		var commands []command.Command
+		var possibleSignerAddresses []string
+
+		events := log.GetEventsByType("channel_open_init")
+		msgRegisterAccountParams := make([]icaauth_model.MsgRegisterAccountParams, 0)
+
+		for _, event := range events {
+			param := icaauth_model.MsgRegisterAccountParams{
+				MsgRegisterAccount: icaauth_model.MsgRegisterAccount{
+					Owner:        msgRegisterAccount.Owner,
+					ConnectionID: event.MustGetAttributeByKey("connection_id"),
+					Version:      event.MustGetAttributeByKey("version"),
+				},
+
+				PortID:                event.MustGetAttributeByKey("port_id"),
+				ChannelID:             event.MustGetAttributeByKey("channel_id"),
+				CounterpartyPortID:    event.MustGetAttributeByKey("counterparty_port_id"),
+				CounterpartyChannelID: event.MustGetAttributeByKey("counterparty_channel_id"),
+			}
+
+			isExisted := false
+			for _, msgRegisterAccountParam := range msgRegisterAccountParams {
+				if msgRegisterAccountParam.ChannelID == param.ChannelID && msgRegisterAccountParam.PortID == param.PortID && msgRegisterAccountParam.CounterpartyChannelID == param.CounterpartyChannelID {
+					isExisted = true
+					break
+				}
+			}
+
+			if !isExisted {
+				// append non-duplicated msg register account params extracted from channel open init event
+				msgRegisterAccountParams = append(msgRegisterAccountParams, param)
+
+				// append commands
+				commands = append(commands, command_usecase.NewCreateMsgRegisterAccount(
+					parserParams.MsgCommonParams,
+					param,
+				))
+
+				// append possible signer addresses
+				possibleSignerAddresses = append(possibleSignerAddresses, rawMsg.Owner)
+			}
+		}
+		return commands, possibleSignerAddresses
+	}
+
 	event := log.GetEventByType("channel_open_init")
 	if event == nil {
 		panic("missing `channel_open_init` event in TxsResult log")

--- a/usecase/parser/msg.go
+++ b/usecase/parser/msg.go
@@ -146,17 +146,17 @@ func ParseBlockTxsMsgToCommands(
 				parser := parserManager.GetParser(utils.CosmosParserKey(msgType.(string)), utils.ParserBlockHeight(blockHeight))
 
 				msgCommands, possibleSignerAddresses = parser(utils.CosmosParserParams{
-					AddressPrefix:      accountAddressPrefix,
-					StakingDenom:       stakingDenom,
-					TxsResult:          txsResult,
-					MsgCommonParams:    msgCommonParams,
-					Msg:                msg,
-					MsgIndex:           msgIndex,
-					ParserManager:      parserManager,
-					Logger:             parserManager.GetLogger(),
-					TxDecoder:          parserManager.TxDecoder,
-					IsProposalInnerMsg: false,
-					IsEvmInnerMsg:      false,
+					AddressPrefix:        accountAddressPrefix,
+					StakingDenom:         stakingDenom,
+					TxsResult:            txsResult,
+					MsgCommonParams:      msgCommonParams,
+					Msg:                  msg,
+					MsgIndex:             msgIndex,
+					ParserManager:        parserManager,
+					Logger:               parserManager.GetLogger(),
+					TxDecoder:            parserManager.TxDecoder,
+					IsProposalInnerMsg:   false,
+					IsEthereumTxInnerMsg: false,
 				})
 			}
 			addresses = append(addresses, possibleSignerAddresses...)
@@ -2344,7 +2344,7 @@ func ParseMsgEthereumTx(
 		log := utils.NewParsedTxsResultLog(&parserParams.TxsResult.Log[parserParams.MsgIndex])
 		events := log.GetEventsByType("channel_open_init")
 		if len(events) > 0 {
-			parserParams.IsEvmInnerMsg = true
+			parserParams.IsEthereumTxInnerMsg = true
 			cmds, signers := icaauth.ParseMsgRegisterAccount(parserParams)
 			commands = append(commands, cmds...)
 			possibleSignerAddresses = append(possibleSignerAddresses, signers...)

--- a/usecase/parser/utils/parsermanager.go
+++ b/usecase/parser/utils/parsermanager.go
@@ -41,17 +41,17 @@ type CosmosParser func(
 ) ([]command.Command, []string)
 
 type CosmosParserParams struct {
-	AddressPrefix      string
-	StakingDenom       string
-	TxsResult          model.BlockResultsTxsResult
-	MsgCommonParams    event.MsgCommonParams
-	MsgIndex           int
-	Msg                map[string]interface{}
-	ParserManager      *CosmosParserManager
-	Logger             applogger.Logger
-	TxDecoder          txdecoder.TxDecoder
-	IsProposalInnerMsg bool
-	IsEvmInnerMsg      bool
+	AddressPrefix        string
+	StakingDenom         string
+	TxsResult            model.BlockResultsTxsResult
+	MsgCommonParams      event.MsgCommonParams
+	MsgIndex             int
+	Msg                  map[string]interface{}
+	ParserManager        *CosmosParserManager
+	Logger               applogger.Logger
+	TxDecoder            txdecoder.TxDecoder
+	IsProposalInnerMsg   bool
+	IsEthereumTxInnerMsg bool
 }
 
 func NewCosmosParserManager(params CosmosParserManagerParams) *CosmosParserManager {

--- a/usecase/parser/utils/parsermanager.go
+++ b/usecase/parser/utils/parsermanager.go
@@ -51,6 +51,7 @@ type CosmosParserParams struct {
 	Logger             applogger.Logger
 	TxDecoder          txdecoder.TxDecoder
 	IsProposalInnerMsg bool
+	IsEvmInnerMsg      bool
 }
 
 func NewCosmosParserManager(params CosmosParserManagerParams) *CosmosParserManager {


### PR DESCRIPTION
- use `IsEvmInnerMsg` in msg parser to separate current and evm tx msg parsing.
- parse ICA msgRegisterAccount by checking `channel_open_init` event
- parse ICA msgSubmitTx by checking `submit_msgs_result` event (do not need to parse the inner msg, it will execute on the host chain rather than controller chain).