### PR TITLE
Fix: ibc transfer parsing inside eth tx

### DIFF
--- a/usecase/parser/ibc/msg.go
+++ b/usecase/parser/ibc/msg.go
@@ -933,43 +933,45 @@ func ParseMsgTransfer(
 		for _, event := range events {
 			// Transfer application, MsgTransfer
 			packetData := event.MustGetAttributeByKey("packet_data")
-			var fungiblePacketData ibc_model.FungibleTokenPacketData
 
+			var fungiblePacketData *ibc_model.FungibleTokenPacketData
 			if unmarshalErr := jsoniter.Unmarshal([]byte(packetData), &fungiblePacketData); unmarshalErr != nil {
 				panic("unable to parse `send_packet` event, key `packet_data`")
 			}
 
-			msgTransferParams := ibc_model.MsgTransferParams{
-				RawMsgTransfer: ibc_model.RawMsgTransfer{
-					Token: ibc_model.MsgTransferToken{
-						Denom:  fungiblePacketData.Denom,
-						Amount: fungiblePacketData.Amount,
+			if fungiblePacketData != nil {
+				msgTransferParams := ibc_model.MsgTransferParams{
+					RawMsgTransfer: ibc_model.RawMsgTransfer{
+						Token: ibc_model.MsgTransferToken{
+							Denom:  fungiblePacketData.Denom,
+							Amount: fungiblePacketData.Amount,
+						},
+						Sender:           fungiblePacketData.Sender,
+						Receiver:         fungiblePacketData.Receiver,
+						SourcePort:       event.MustGetAttributeByKey("packet_src_port"),
+						SourceChannel:    event.MustGetAttributeByKey("packet_src_channel"),
+						TimeoutHeight:    MustParseHeight(event.MustGetAttributeByKey("packet_timeout_height")),
+						TimeoutTimestamp: event.MustGetAttributeByKey("packet_timeout_timestamp"),
 					},
-					Sender:           fungiblePacketData.Sender,
-					Receiver:         fungiblePacketData.Receiver,
-					SourcePort:       event.MustGetAttributeByKey("packet_src_port"),
-					SourceChannel:    event.MustGetAttributeByKey("packet_src_channel"),
-					TimeoutHeight:    MustParseHeight(event.MustGetAttributeByKey("packet_timeout_height")),
-					TimeoutTimestamp: event.MustGetAttributeByKey("packet_timeout_timestamp"),
-				},
 
-				PacketSequence:     typeconv.MustAtou64(event.MustGetAttributeByKey("packet_sequence")),
-				DestinationPort:    event.MustGetAttributeByKey("packet_dst_port"),
-				DestinationChannel: event.MustGetAttributeByKey("packet_dst_channel"),
-				ChannelOrdering:    event.MustGetAttributeByKey("packet_channel_ordering"),
-				ConnectionID:       event.MustGetAttributeByKey("packet_connection"),
-				PacketData:         fungiblePacketData,
+					PacketSequence:     typeconv.MustAtou64(event.MustGetAttributeByKey("packet_sequence")),
+					DestinationPort:    event.MustGetAttributeByKey("packet_dst_port"),
+					DestinationChannel: event.MustGetAttributeByKey("packet_dst_channel"),
+					ChannelOrdering:    event.MustGetAttributeByKey("packet_channel_ordering"),
+					ConnectionID:       event.MustGetAttributeByKey("packet_connection"),
+					PacketData:         *fungiblePacketData,
+				}
+
+				// Getting possible signer address from Msg
+				var possibleSignerAddresses []string
+				possibleSignerAddresses = append(possibleSignerAddresses, msgTransferParams.Sender)
+
+				return []command.Command{command_usecase.NewCreateMsgIBCTransferTransfer(
+					parserParams.MsgCommonParams,
+
+					msgTransferParams,
+				)}, possibleSignerAddresses
 			}
-
-			// Getting possible signer address from Msg
-			var possibleSignerAddresses []string
-			possibleSignerAddresses = append(possibleSignerAddresses, msgTransferParams.Sender)
-
-			return []command.Command{command_usecase.NewCreateMsgIBCTransferTransfer(
-				parserParams.MsgCommonParams,
-
-				msgTransferParams,
-			)}, possibleSignerAddresses
 		}
 	}
 

--- a/usecase/parser/ibc/msg.go
+++ b/usecase/parser/ibc/msg.go
@@ -930,8 +930,6 @@ func ParseMsgTransfer(
 
 	if parserParams.IsEthereumTxInnerMsg {
 		events := log.GetEventsByType("send_packet")
-
-		var msgTransferParams ibc_model.MsgTransferParams
 		for _, event := range events {
 			// Transfer application, MsgTransfer
 			packetData := event.MustGetAttributeByKey("packet_data")
@@ -941,7 +939,7 @@ func ParseMsgTransfer(
 				panic("unable to parse `send_packet` event, key `packet_data`")
 			}
 
-			msgTransferParams = ibc_model.MsgTransferParams{
+			msgTransferParams := ibc_model.MsgTransferParams{
 				RawMsgTransfer: ibc_model.RawMsgTransfer{
 					Token: ibc_model.MsgTransferToken{
 						Denom:  fungiblePacketData.Denom,
@@ -962,17 +960,17 @@ func ParseMsgTransfer(
 				ConnectionID:       event.MustGetAttributeByKey("packet_connection"),
 				PacketData:         fungiblePacketData,
 			}
+
+			// Getting possible signer address from Msg
+			var possibleSignerAddresses []string
+			possibleSignerAddresses = append(possibleSignerAddresses, msgTransferParams.Sender)
+
+			return []command.Command{command_usecase.NewCreateMsgIBCTransferTransfer(
+				parserParams.MsgCommonParams,
+
+				msgTransferParams,
+			)}, possibleSignerAddresses
 		}
-
-		// Getting possible signer address from Msg
-		var possibleSignerAddresses []string
-		possibleSignerAddresses = append(possibleSignerAddresses, msgTransferParams.Sender)
-
-		return []command.Command{command_usecase.NewCreateMsgIBCTransferTransfer(
-			parserParams.MsgCommonParams,
-
-			msgTransferParams,
-		)}, possibleSignerAddresses
 	}
 
 	event := log.GetEventByType("send_packet")

--- a/usecase/parser/msg.go
+++ b/usecase/parser/msg.go
@@ -2505,7 +2505,8 @@ func ParseMsgEthereumTx(
 		// parse msgTransfer
 		case log.HasEvent("send_packet"):
 			{
-				if log.GetEventByType("send_packet") != nil {
+				sendEvents := log.GetEventsByType("send_packet")
+				if len(sendEvents) > 0 {
 					parserParams.IsEthereumTxInnerMsg = true
 					cmds, signers := ibc.ParseMsgTransfer(parserParams)
 					commands = append(commands, cmds...)


### PR DESCRIPTION
Issue
- Ibc transfer emits more than one `send_packet` event inside etherum tx and got panic

Solution
- use `GetEventsByType` instead of `GetEventByType` to loop through the events
