### PR TITLE
Fix: skip msg cosmos.consensus.v1.MsgUpdateParams in submit proposal parser

### DIFF
--- a/usecase/parser/gov/v1/msg.go
+++ b/usecase/parser/gov/v1/msg.go
@@ -128,7 +128,8 @@ func ParseMsgSubmitProposal(
 		case "/cosmos.gov.v1.MsgExecLegacyContent",
 			"/cosmos.upgrade.v1beta1.MsgSoftwareUpgrade",
 			"/cosmos.upgrade.v1beta1.MsgCancelUpgrade",
-			"/ethermint.feemarket.v1.MsgUpdateParams":
+			"/ethermint.feemarket.v1.MsgUpdateParams",
+			"/cosmos.consensus.v1.MsgUpdateParams":
 			break
 		default:
 			parser := parserParams.ParserManager.GetParser(utils.CosmosParserKey(innerMsgType), utils.ParserBlockHeight(blockHeight))


### PR DESCRIPTION
Proposal with msg `/cosmos.consensus.v1.MsgUpdateParams`: http://internal-testnet2-cronos-internal-fn-alb-1137839070.ap-southeast-1.elb.amazonaws.com:1317/cosmos/gov/v1beta1/proposals/29