### PR TITLE
feat: support more fields on tier msgs

### DIFF
--- a/usecase/event/msg_tier_claim_tier_rewards.go
+++ b/usecase/event/msg_tier_claim_tier_rewards.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 
 	entity_event "github.com/crypto-com/chain-indexing/entity/event"
-"github.com/crypto-com/chain-indexing/usecase/model"
+	"github.com/crypto-com/chain-indexing/usecase/model"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/luci/go-render/render"
 )
@@ -15,10 +15,10 @@ const MSG_TIER_CLAIM_TIER_REWARDS_FAILED = "/chainmain.tieredrewards.v1.MsgClaim
 
 type MsgTierClaimTierRewards struct {
 	MsgBase
-	Owner        string     `json:"owner"`
-	PositionIds  []string   `json:"positionIds"`
-	BaseRewards  string `json:"baseRewards"`
-	BonusRewards string `json:"bonusRewards"`
+	Owner        string   `json:"owner"`
+	PositionIds  []string `json:"positionIds"`
+	BaseRewards  string   `json:"baseRewards"`
+	BonusRewards string   `json:"bonusRewards"`
 }
 
 func NewMsgTierClaimTierRewards(msgCommonParams MsgCommonParams, params model.MsgClaimTierRewardsParams) *MsgTierClaimTierRewards {

--- a/usecase/event/msg_tier_claim_tier_rewards.go
+++ b/usecase/event/msg_tier_claim_tier_rewards.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 
 	entity_event "github.com/crypto-com/chain-indexing/entity/event"
-	"github.com/crypto-com/chain-indexing/usecase/model"
+"github.com/crypto-com/chain-indexing/usecase/model"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/luci/go-render/render"
 )
@@ -15,8 +15,10 @@ const MSG_TIER_CLAIM_TIER_REWARDS_FAILED = "/chainmain.tieredrewards.v1.MsgClaim
 
 type MsgTierClaimTierRewards struct {
 	MsgBase
-	Owner       string   `json:"owner"`
-	PositionIds []string `json:"positionIds"`
+	Owner        string     `json:"owner"`
+	PositionIds  []string   `json:"positionIds"`
+	BaseRewards  string `json:"baseRewards"`
+	BonusRewards string `json:"bonusRewards"`
 }
 
 func NewMsgTierClaimTierRewards(msgCommonParams MsgCommonParams, params model.MsgClaimTierRewardsParams) *MsgTierClaimTierRewards {
@@ -28,6 +30,8 @@ func NewMsgTierClaimTierRewards(msgCommonParams MsgCommonParams, params model.Ms
 		}),
 		params.Owner,
 		params.PositionIds,
+		params.BaseRewards,
+		params.BonusRewards,
 	}
 }
 

--- a/usecase/event/msg_tier_commit_delegation_to_tier.go
+++ b/usecase/event/msg_tier_commit_delegation_to_tier.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 
 	entity_event "github.com/crypto-com/chain-indexing/entity/event"
+	"github.com/crypto-com/chain-indexing/usecase/model"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/luci/go-render/render"
-	"github.com/crypto-com/chain-indexing/usecase/model"
 )
 
 const MSG_TIER_COMMIT_DELEGATION_TO_TIER = "/chainmain.tieredrewards.v1.MsgCommitDelegationToTier"
@@ -20,6 +20,7 @@ type MsgTierCommitDelegationToTier struct {
 	Amount                 string `json:"amount"`
 	Id                     uint32 `json:"id"`
 	TriggerExitImmediately bool   `json:"triggerExitImmediately"`
+	PositionId             string `json:"positionId"`
 }
 
 func NewMsgTierCommitDelegationToTier(msgCommonParams MsgCommonParams, params model.MsgCommitDelegationToTierParams) *MsgTierCommitDelegationToTier {
@@ -34,6 +35,7 @@ func NewMsgTierCommitDelegationToTier(msgCommonParams MsgCommonParams, params mo
 		params.Amount,
 		params.Id,
 		params.TriggerExitImmediately,
+		params.PositionId,
 	}
 }
 

--- a/usecase/event/msg_tier_exit_tier_with_delegation.go
+++ b/usecase/event/msg_tier_exit_tier_with_delegation.go
@@ -15,9 +15,12 @@ const MSG_TIER_EXIT_TIER_WITH_DELEGATION_FAILED = "/chainmain.tieredrewards.v1.M
 
 type MsgTierExitTierWithDelegation struct {
 	MsgBase
-	Owner      string `json:"owner"`
-	PositionId string `json:"positionId"`
-	Amount     string `json:"amount"`
+	Owner             string `json:"owner"`
+	PositionId        string `json:"positionId"`
+	Amount            string `json:"amount"`
+	TransferredAmount string `json:"transferredAmount"`
+	TransferredShares string `json:"transferredShares"`
+	FullExit          bool   `json:"fullExit"`
 }
 
 func NewMsgTierExitTierWithDelegation(msgCommonParams MsgCommonParams, params model.MsgExitTierWithDelegationParams) *MsgTierExitTierWithDelegation {
@@ -30,6 +33,9 @@ func NewMsgTierExitTierWithDelegation(msgCommonParams MsgCommonParams, params mo
 		params.Owner,
 		params.PositionId,
 		params.Amount,
+		params.TransferredAmount,
+		params.TransferredShares,
+		params.FullExit,
 	}
 }
 

--- a/usecase/event/msg_tier_lock_tier.go
+++ b/usecase/event/msg_tier_lock_tier.go
@@ -20,6 +20,7 @@ type MsgTierLockTier struct {
 	Amount                 string `json:"amount"`
 	ValidatorAddress       string `json:"validatorAddress"`
 	TriggerExitImmediately bool   `json:"triggerExitImmediately"`
+	PositionId             string `json:"positionId"`
 }
 
 func NewMsgTierLockTier(msgCommonParams MsgCommonParams, params model.MsgLockTierParams) *MsgTierLockTier {
@@ -34,6 +35,7 @@ func NewMsgTierLockTier(msgCommonParams MsgCommonParams, params model.MsgLockTie
 		params.Amount,
 		params.ValidatorAddress,
 		params.TriggerExitImmediately,
+		params.PositionId,
 	}
 }
 

--- a/usecase/event/msg_tier_redelegate.go
+++ b/usecase/event/msg_tier_redelegate.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 
 	entity_event "github.com/crypto-com/chain-indexing/entity/event"
+	"github.com/crypto-com/chain-indexing/usecase/model"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/luci/go-render/render"
-	"github.com/crypto-com/chain-indexing/usecase/model"
 )
 
 const MSG_TIER_REDELEGATE = "/chainmain.tieredrewards.v1.MsgTierRedelegate"
@@ -15,9 +15,11 @@ const MSG_TIER_REDELEGATE_FAILED = "/chainmain.tieredrewards.v1.MsgTierRedelegat
 
 type MsgTierRedelegate struct {
 	MsgBase
-	Owner        string `json:"owner"`
-	PositionId   string `json:"positionId"`
-	DstValidator string `json:"dstValidator"`
+	Owner          string `json:"owner"`
+	PositionId     string `json:"positionId"`
+	DstValidator   string `json:"dstValidator"`
+	CompletionTime string `json:"completionTime"`
+	UnbondingId    string `json:"unbondingId"`
 }
 
 func NewMsgTierRedelegate(msgCommonParams MsgCommonParams, params model.MsgTierRedelegateParams) *MsgTierRedelegate {
@@ -30,6 +32,8 @@ func NewMsgTierRedelegate(msgCommonParams MsgCommonParams, params model.MsgTierR
 		params.Owner,
 		params.PositionId,
 		params.DstValidator,
+		params.CompletionTime,
+		params.UnbondingId,
 	}
 }
 

--- a/usecase/event/msg_tier_trigger_exit_from_tier.go
+++ b/usecase/event/msg_tier_trigger_exit_from_tier.go
@@ -15,8 +15,9 @@ const MSG_TIER_TRIGGER_EXIT_FROM_TIER_FAILED = "/chainmain.tieredrewards.v1.MsgT
 
 type MsgTierTriggerExitFromTier struct {
 	MsgBase
-	Owner      string `json:"owner"`
-	PositionId string `json:"positionId"`
+	Owner        string `json:"owner"`
+	PositionId   string `json:"positionId"`
+	ExitUnlockAt string `json:"exitUnlockAt"`
 }
 
 func NewMsgTierTriggerExitFromTier(msgCommonParams MsgCommonParams, params model.MsgTriggerExitFromTierParams) *MsgTierTriggerExitFromTier {
@@ -28,6 +29,7 @@ func NewMsgTierTriggerExitFromTier(msgCommonParams MsgCommonParams, params model
 		}),
 		params.Owner,
 		params.PositionId,
+		params.ExitUnlockAt,
 	}
 }
 

--- a/usecase/event/msg_tier_undelegate.go
+++ b/usecase/event/msg_tier_undelegate.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 
 	entity_event "github.com/crypto-com/chain-indexing/entity/event"
+	"github.com/crypto-com/chain-indexing/usecase/model"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/luci/go-render/render"
-	"github.com/crypto-com/chain-indexing/usecase/model"
 )
 
 const MSG_TIER_UNDELEGATE = "/chainmain.tieredrewards.v1.MsgTierUndelegate"
@@ -15,8 +15,10 @@ const MSG_TIER_UNDELEGATE_FAILED = "/chainmain.tieredrewards.v1.MsgTierUndelegat
 
 type MsgTierUndelegate struct {
 	MsgBase
-	Owner      string `json:"owner"`
-	PositionId string `json:"positionId"`
+	Owner          string `json:"owner"`
+	PositionId     string `json:"positionId"`
+	CompletionTime string `json:"completionTime"`
+	UnbondingId    string `json:"unbondingId"`
 }
 
 func NewMsgTierUndelegate(msgCommonParams MsgCommonParams, params model.MsgTierUndelegateParams) *MsgTierUndelegate {
@@ -28,6 +30,8 @@ func NewMsgTierUndelegate(msgCommonParams MsgCommonParams, params model.MsgTierU
 		}),
 		params.Owner,
 		params.PositionId,
+		params.CompletionTime,
+		params.UnbondingId,
 	}
 }
 

--- a/usecase/event/msg_tier_withdraw_from_tier.go
+++ b/usecase/event/msg_tier_withdraw_from_tier.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 
 	entity_event "github.com/crypto-com/chain-indexing/entity/event"
-	"github.com/crypto-com/chain-indexing/usecase/model"
+"github.com/crypto-com/chain-indexing/usecase/model"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/luci/go-render/render"
 )
@@ -15,8 +15,9 @@ const MSG_TIER_WITHDRAW_FROM_TIER_FAILED = "/chainmain.tieredrewards.v1.MsgWithd
 
 type MsgTierWithdrawFromTier struct {
 	MsgBase
-	Owner      string `json:"owner"`
-	PositionId string `json:"positionId"`
+	Owner      string     `json:"owner"`
+	PositionId string     `json:"positionId"`
+	Amount     string     `json:"amount"`
 }
 
 func NewMsgTierWithdrawFromTier(msgCommonParams MsgCommonParams, params model.MsgWithdrawFromTierParams) *MsgTierWithdrawFromTier {
@@ -28,6 +29,7 @@ func NewMsgTierWithdrawFromTier(msgCommonParams MsgCommonParams, params model.Ms
 		}),
 		params.Owner,
 		params.PositionId,
+		params.Amount,
 	}
 }
 

--- a/usecase/model/msg_tier_claim_tier_rewards.go
+++ b/usecase/model/msg_tier_claim_tier_rewards.go
@@ -2,6 +2,9 @@ package model
 
 type MsgClaimTierRewardsParams struct {
 	RawMsgClaimTierRewards
+
+	BaseRewards  string `json:"baseRewards"`
+	BonusRewards string `json:"bonusRewards"`
 }
 
 type RawMsgClaimTierRewards struct {

--- a/usecase/model/msg_tier_commit_delegation_to_tier.go
+++ b/usecase/model/msg_tier_commit_delegation_to_tier.go
@@ -2,6 +2,8 @@ package model
 
 type MsgCommitDelegationToTierParams struct {
 	RawMsgCommitDelegationToTier
+
+	PositionId string `json:"positionId"`
 }
 
 type RawMsgCommitDelegationToTier struct {

--- a/usecase/model/msg_tier_exit_tier_with_delegation.go
+++ b/usecase/model/msg_tier_exit_tier_with_delegation.go
@@ -2,6 +2,10 @@ package model
 
 type MsgExitTierWithDelegationParams struct {
 	RawMsgExitTierWithDelegation
+
+	TransferredAmount string `json:"transferredAmount"`
+	TransferredShares string `json:"transferredShares"`
+	FullExit          bool   `json:"fullExit"`
 }
 
 type RawMsgExitTierWithDelegation struct {

--- a/usecase/model/msg_tier_lock_tier.go
+++ b/usecase/model/msg_tier_lock_tier.go
@@ -2,6 +2,8 @@ package model
 
 type MsgLockTierParams struct {
 	RawMsgLockTier
+
+	PositionId string `json:"positionId"`
 }
 
 type RawMsgLockTier struct {

--- a/usecase/model/msg_tier_redelegate.go
+++ b/usecase/model/msg_tier_redelegate.go
@@ -2,6 +2,9 @@ package model
 
 type MsgTierRedelegateParams struct {
 	RawMsgTierRedelegate
+
+	CompletionTime string `json:"completionTime"`
+	UnbondingId    string `json:"unbondingId"`
 }
 
 type RawMsgTierRedelegate struct {

--- a/usecase/model/msg_tier_trigger_exit_from_tier.go
+++ b/usecase/model/msg_tier_trigger_exit_from_tier.go
@@ -2,6 +2,8 @@ package model
 
 type MsgTriggerExitFromTierParams struct {
 	RawMsgTriggerExitFromTier
+
+	ExitUnlockAt string `json:"exitUnlockAt"`
 }
 
 type RawMsgTriggerExitFromTier struct {

--- a/usecase/model/msg_tier_undelegate.go
+++ b/usecase/model/msg_tier_undelegate.go
@@ -2,6 +2,9 @@ package model
 
 type MsgTierUndelegateParams struct {
 	RawMsgTierUndelegate
+
+	CompletionTime string `json:"completionTime"`
+	UnbondingId    string `json:"unbondingId"`
 }
 
 type RawMsgTierUndelegate struct {

--- a/usecase/model/msg_tier_withdraw_from_tier.go
+++ b/usecase/model/msg_tier_withdraw_from_tier.go
@@ -2,6 +2,8 @@ package model
 
 type MsgWithdrawFromTierParams struct {
 	RawMsgWithdrawFromTier
+
+	Amount string `json:"amount"`
 }
 
 type RawMsgWithdrawFromTier struct {

--- a/usecase/parser/msg.go
+++ b/usecase/parser/msg.go
@@ -2644,7 +2644,7 @@ func ParseMsgTierLockTier(
 		for _, event := range events.GetEventsByType("chainmain.tieredrewards.v1.EventPositionCreated") {
 			if msgIndex := event.GetAttributeByKey("msg_index"); msgIndex != nil && *msgIndex == strconv.Itoa(parserParams.MsgIndex) {
 				if positionId := event.GetAttributeByKey("position_id"); positionId != nil {
-					params.PositionId = *positionId
+					params.PositionId = utils.UnquoteOrRaw(*positionId)
 				}
 				break
 			}
@@ -2691,7 +2691,7 @@ func ParseMsgTierCommitDelegationToTier(
 		for _, event := range events.GetEventsByType("chainmain.tieredrewards.v1.EventDelegationCommitted") {
 			if msgIndex := event.GetAttributeByKey("msg_index"); msgIndex != nil && *msgIndex == strconv.Itoa(parserParams.MsgIndex) {
 				if positionId := event.GetAttributeByKey("position_id"); positionId != nil {
-					params.PositionId = *positionId
+					params.PositionId = utils.UnquoteOrRaw(*positionId)
 				}
 				break
 			}
@@ -2738,7 +2738,7 @@ func ParseMsgTierAddToTierPosition(
 		for _, event := range events.GetEventsByType("chainmain.tieredrewards.v1.EventPositionAmountAdded") {
 			if msgIndex := event.GetAttributeByKey("msg_index"); msgIndex != nil && *msgIndex == strconv.Itoa(parserParams.MsgIndex) {
 				if positionId := event.GetAttributeByKey("position_id"); positionId != nil {
-					params.PositionId = *positionId
+					params.PositionId = utils.UnquoteOrRaw(*positionId)
 				}
 				break
 			}
@@ -2823,10 +2823,10 @@ func ParseMsgTierRedelegate(
 					params.CompletionTime = *completionTime
 				}
 				if positionId := event.GetAttributeByKey("position_id"); positionId != nil {
-					params.PositionId = *positionId
+					params.PositionId = utils.UnquoteOrRaw(*positionId)
 				}
 				if unbondingId := event.GetAttributeByKey("unbonding_id"); unbondingId != nil {
-					params.UnbondingId = *unbondingId
+					params.UnbondingId = utils.UnquoteOrRaw(*unbondingId)
 				}
 				break
 			}
@@ -2873,13 +2873,13 @@ func ParseMsgTierUndelegate(
 		for _, event := range events.GetEventsByType("chainmain.tieredrewards.v1.EventPositionUndelegated") {
 			if msgIndex := event.GetAttributeByKey("msg_index"); msgIndex != nil && *msgIndex == strconv.Itoa(parserParams.MsgIndex) {
 				if completionTime := event.GetAttributeByKey("completion_time"); completionTime != nil {
-					params.CompletionTime = *completionTime
+					params.CompletionTime = utils.UnquoteOrRaw(*completionTime)
 				}
 				if positionId := event.GetAttributeByKey("position_id"); positionId != nil {
-					params.PositionId = *positionId
+					params.PositionId = utils.UnquoteOrRaw(*positionId)
 				}
 				if unbondingId := event.GetAttributeByKey("unbonding_id"); unbondingId != nil {
-					params.UnbondingId = *unbondingId
+					params.UnbondingId = utils.UnquoteOrRaw(*unbondingId)
 				}
 				break
 			}
@@ -2926,10 +2926,10 @@ func ParseMsgTierTriggerExitFromTier(
 		for _, event := range events.GetEventsByType("chainmain.tieredrewards.v1.EventExitTriggered") {
 			if msgIndex := event.GetAttributeByKey("msg_index"); msgIndex != nil && *msgIndex == strconv.Itoa(parserParams.MsgIndex) {
 				if exitUnlockAt := event.GetAttributeByKey("exit_unlock_at"); exitUnlockAt != nil {
-					params.ExitUnlockAt = *exitUnlockAt
+					params.ExitUnlockAt = utils.UnquoteOrRaw(*exitUnlockAt)
 				}
 				if positionId := event.GetAttributeByKey("position_id"); positionId != nil {
-					params.PositionId = *positionId
+					params.PositionId = utils.UnquoteOrRaw(*positionId)
 				}
 				break
 			}
@@ -2976,7 +2976,7 @@ func ParseMsgTierClearPosition(
 		for _, event := range events.GetEventsByType("chainmain.tieredrewards.v1.EventExitCleared") {
 			if msgIndex := event.GetAttributeByKey("msg_index"); msgIndex != nil && *msgIndex == strconv.Itoa(parserParams.MsgIndex) {
 				if positionId := event.GetAttributeByKey("position_id"); positionId != nil {
-					params.PositionId = *positionId
+					params.PositionId = utils.UnquoteOrRaw(*positionId)
 				}
 				break
 			}
@@ -3127,13 +3127,13 @@ func ParseMsgTierExitTierWithDelegation(
 		for _, event := range events.GetEventsByType("chainmain.tieredrewards.v1.EventExitTierWithDelegation") {
 			if msgIndex := event.GetAttributeByKey("msg_index"); msgIndex != nil && *msgIndex == strconv.Itoa(parserParams.MsgIndex) {
 				if positionId := event.GetAttributeByKey("position_id"); positionId != nil {
-					params.PositionId = *positionId
+					params.PositionId = utils.UnquoteOrRaw(*positionId)
 				}
 				if transferredAmount := event.GetAttributeByKey("transferred_amount"); transferredAmount != nil {
-					params.TransferredAmount = *transferredAmount
+					params.TransferredAmount = utils.UnquoteOrRaw(*transferredAmount)
 				}
 				if transferredShares := event.GetAttributeByKey("transferred_shares"); transferredShares != nil {
-					params.TransferredShares = *transferredShares
+					params.TransferredShares = utils.UnquoteOrRaw(*transferredShares)
 				}
 				if fullExit := event.GetAttributeByKey("full_exit"); fullExit != nil {
 					params.FullExit = *fullExit == "true"

--- a/usecase/parser/msg.go
+++ b/usecase/parser/msg.go
@@ -2639,6 +2639,18 @@ func ParseMsgTierLockTier(
 		possibleSignerAddresses = append(possibleSignerAddresses, rawMsg.Owner)
 	}
 
+	if parserParams.MsgCommonParams.TxSuccess {
+		events := utils.NewParsedTxsResultsEvents(parserParams.TxsResult.Events)
+		for _, event := range events.GetEventsByType("chainmain.tieredrewards.v1.EventPositionCreated") {
+			if msgIndex := event.GetAttributeByKey("msg_index"); msgIndex != nil && *msgIndex == strconv.Itoa(parserParams.MsgIndex) {
+				if positionId := event.GetAttributeByKey("position_id"); positionId != nil {
+					params.PositionId = *positionId
+				}
+				break
+			}
+		}
+	}
+
 	return []command.Command{command_usecase.NewCreateMsgTierLockTier(
 		parserParams.MsgCommonParams,
 		params,
@@ -2674,6 +2686,18 @@ func ParseMsgTierCommitDelegationToTier(
 		possibleSignerAddresses = append(possibleSignerAddresses, rawMsg.DelegatorAddress)
 	}
 
+	if parserParams.MsgCommonParams.TxSuccess {
+		events := utils.NewParsedTxsResultsEvents(parserParams.TxsResult.Events)
+		for _, event := range events.GetEventsByType("chainmain.tieredrewards.v1.EventDelegationCommitted") {
+			if msgIndex := event.GetAttributeByKey("msg_index"); msgIndex != nil && *msgIndex == strconv.Itoa(parserParams.MsgIndex) {
+				if positionId := event.GetAttributeByKey("position_id"); positionId != nil {
+					params.PositionId = *positionId
+				}
+				break
+			}
+		}
+	}
+
 	return []command.Command{command_usecase.NewCreateMsgTierCommitDelegationToTier(
 		parserParams.MsgCommonParams,
 		params,
@@ -2707,6 +2731,18 @@ func ParseMsgTierAddToTierPosition(
 	var possibleSignerAddresses []string
 	if rawMsg.Owner != "" {
 		possibleSignerAddresses = append(possibleSignerAddresses, rawMsg.Owner)
+	}
+
+	if parserParams.MsgCommonParams.TxSuccess {
+		events := utils.NewParsedTxsResultsEvents(parserParams.TxsResult.Events)
+		for _, event := range events.GetEventsByType("chainmain.tieredrewards.v1.EventPositionAmountAdded") {
+			if msgIndex := event.GetAttributeByKey("msg_index"); msgIndex != nil && *msgIndex == strconv.Itoa(parserParams.MsgIndex) {
+				if positionId := event.GetAttributeByKey("position_id"); positionId != nil {
+					params.PositionId = *positionId
+				}
+				break
+			}
+		}
 	}
 
 	return []command.Command{command_usecase.NewCreateMsgTierAddToTierPosition(
@@ -2779,6 +2815,24 @@ func ParseMsgTierRedelegate(
 		possibleSignerAddresses = append(possibleSignerAddresses, rawMsg.Owner)
 	}
 
+	if parserParams.MsgCommonParams.TxSuccess {
+		events := utils.NewParsedTxsResultsEvents(parserParams.TxsResult.Events)
+		for _, event := range events.GetEventsByType("chainmain.tieredrewards.v1.EventPositionRedelegated") {
+			if msgIndex := event.GetAttributeByKey("msg_index"); msgIndex != nil && *msgIndex == strconv.Itoa(parserParams.MsgIndex) {
+				if completionTime := event.GetAttributeByKey("completion_time"); completionTime != nil {
+					params.CompletionTime = *completionTime
+				}
+				if positionId := event.GetAttributeByKey("position_id"); positionId != nil {
+					params.PositionId = *positionId
+				}
+				if unbondingId := event.GetAttributeByKey("unbonding_id"); unbondingId != nil {
+					params.UnbondingId = *unbondingId
+				}
+				break
+			}
+		}
+	}
+
 	return []command.Command{command_usecase.NewCreateMsgTierRedelegate(
 		parserParams.MsgCommonParams,
 		params,
@@ -2812,6 +2866,24 @@ func ParseMsgTierUndelegate(
 	var possibleSignerAddresses []string
 	if rawMsg.Owner != "" {
 		possibleSignerAddresses = append(possibleSignerAddresses, rawMsg.Owner)
+	}
+
+	if parserParams.MsgCommonParams.TxSuccess {
+		events := utils.NewParsedTxsResultsEvents(parserParams.TxsResult.Events)
+		for _, event := range events.GetEventsByType("chainmain.tieredrewards.v1.EventPositionUndelegated") {
+			if msgIndex := event.GetAttributeByKey("msg_index"); msgIndex != nil && *msgIndex == strconv.Itoa(parserParams.MsgIndex) {
+				if completionTime := event.GetAttributeByKey("completion_time"); completionTime != nil {
+					params.CompletionTime = *completionTime
+				}
+				if positionId := event.GetAttributeByKey("position_id"); positionId != nil {
+					params.PositionId = *positionId
+				}
+				if unbondingId := event.GetAttributeByKey("unbonding_id"); unbondingId != nil {
+					params.UnbondingId = *unbondingId
+				}
+				break
+			}
+		}
 	}
 
 	return []command.Command{command_usecase.NewCreateMsgTierUndelegate(
@@ -2849,6 +2921,21 @@ func ParseMsgTierTriggerExitFromTier(
 		possibleSignerAddresses = append(possibleSignerAddresses, rawMsg.Owner)
 	}
 
+	if parserParams.MsgCommonParams.TxSuccess {
+		events := utils.NewParsedTxsResultsEvents(parserParams.TxsResult.Events)
+		for _, event := range events.GetEventsByType("chainmain.tieredrewards.v1.EventExitTriggered") {
+			if msgIndex := event.GetAttributeByKey("msg_index"); msgIndex != nil && *msgIndex == strconv.Itoa(parserParams.MsgIndex) {
+				if exitUnlockAt := event.GetAttributeByKey("exit_unlock_at"); exitUnlockAt != nil {
+					params.ExitUnlockAt = *exitUnlockAt
+				}
+				if positionId := event.GetAttributeByKey("position_id"); positionId != nil {
+					params.PositionId = *positionId
+				}
+				break
+			}
+		}
+	}
+
 	return []command.Command{command_usecase.NewCreateMsgTierTriggerExitFromTier(
 		parserParams.MsgCommonParams,
 		params,
@@ -2882,6 +2969,18 @@ func ParseMsgTierClearPosition(
 	var possibleSignerAddresses []string
 	if rawMsg.Owner != "" {
 		possibleSignerAddresses = append(possibleSignerAddresses, rawMsg.Owner)
+	}
+
+	if parserParams.MsgCommonParams.TxSuccess {
+		events := utils.NewParsedTxsResultsEvents(parserParams.TxsResult.Events)
+		for _, event := range events.GetEventsByType("chainmain.tieredrewards.v1.EventExitCleared") {
+			if msgIndex := event.GetAttributeByKey("msg_index"); msgIndex != nil && *msgIndex == strconv.Itoa(parserParams.MsgIndex) {
+				if positionId := event.GetAttributeByKey("position_id"); positionId != nil {
+					params.PositionId = *positionId
+				}
+				break
+			}
+		}
 	}
 
 	return []command.Command{command_usecase.NewCreateMsgTierClearPosition(
@@ -2919,6 +3018,18 @@ func ParseMsgTierWithdrawFromTier(
 		possibleSignerAddresses = append(possibleSignerAddresses, rawMsg.Owner)
 	}
 
+	if parserParams.MsgCommonParams.TxSuccess {
+		events := utils.NewParsedTxsResultsEvents(parserParams.TxsResult.Events)
+		for _, event := range events.GetEventsByType("chainmain.tieredrewards.v1.EventPositionWithdrawn") {
+			if msgIndex := event.GetAttributeByKey("msg_index"); msgIndex != nil && *msgIndex == strconv.Itoa(parserParams.MsgIndex) {
+				if amount := event.GetAttributeByKey("amount"); amount != nil {
+					params.Amount = *amount
+					break
+				}
+			}
+		}
+	}
+
 	return []command.Command{command_usecase.NewCreateMsgTierWithdrawFromTier(
 		parserParams.MsgCommonParams,
 		params,
@@ -2947,11 +3058,33 @@ func ParseMsgTierClaimTierRewards(
 		panic(fmt.Errorf("error decoding ParseMsgTierClaimTierRewards: %v", err))
 	}
 
-	params := model.MsgClaimTierRewardsParams{RawMsgClaimTierRewards: rawMsg}
-
 	var possibleSignerAddresses []string
 	if rawMsg.Owner != "" {
 		possibleSignerAddresses = append(possibleSignerAddresses, rawMsg.Owner)
+	}
+
+	var baseRewards string
+	var bonusRewards string
+
+	if parserParams.MsgCommonParams.TxSuccess {
+		events := utils.NewParsedTxsResultsEvents(parserParams.TxsResult.Events)
+		for _, event := range events.GetEventsByType("chainmain.tieredrewards.v1.EventTierRewardsClaimed") {
+			if msgIndex := event.GetAttributeByKey("msg_index"); msgIndex != nil && *msgIndex == strconv.Itoa(parserParams.MsgIndex) {
+				if baseRewardsValue := event.GetAttributeByKey("base_rewards"); baseRewardsValue != nil {
+					baseRewards = *baseRewardsValue
+				}
+				if bonusRewardsValue := event.GetAttributeByKey("bonus_rewards"); bonusRewardsValue != nil {
+					bonusRewards = *bonusRewardsValue
+				}
+				break
+			}
+		}
+	}
+
+	params := model.MsgClaimTierRewardsParams{
+		RawMsgClaimTierRewards: rawMsg,
+		BaseRewards:            baseRewards,
+		BonusRewards:           bonusRewards,
 	}
 
 	return []command.Command{command_usecase.NewCreateMsgTierClaimTierRewards(
@@ -2987,6 +3120,27 @@ func ParseMsgTierExitTierWithDelegation(
 	var possibleSignerAddresses []string
 	if rawMsg.Owner != "" {
 		possibleSignerAddresses = append(possibleSignerAddresses, rawMsg.Owner)
+	}
+
+	if parserParams.MsgCommonParams.TxSuccess {
+		events := utils.NewParsedTxsResultsEvents(parserParams.TxsResult.Events)
+		for _, event := range events.GetEventsByType("chainmain.tieredrewards.v1.EventExitTierWithDelegation") {
+			if msgIndex := event.GetAttributeByKey("msg_index"); msgIndex != nil && *msgIndex == strconv.Itoa(parserParams.MsgIndex) {
+				if positionId := event.GetAttributeByKey("position_id"); positionId != nil {
+					params.PositionId = *positionId
+				}
+				if transferredAmount := event.GetAttributeByKey("transferred_amount"); transferredAmount != nil {
+					params.TransferredAmount = *transferredAmount
+				}
+				if transferredShares := event.GetAttributeByKey("transferred_shares"); transferredShares != nil {
+					params.TransferredShares = *transferredShares
+				}
+				if fullExit := event.GetAttributeByKey("full_exit"); fullExit != nil {
+					params.FullExit = *fullExit == "true"
+				}
+				break
+			}
+		}
 	}
 
 	return []command.Command{command_usecase.NewCreateMsgTierExitTierWithDelegation(

--- a/usecase/parser/msg_tier_claim_tier_rewards_test.go
+++ b/usecase/parser/msg_tier_claim_tier_rewards_test.go
@@ -19,7 +19,7 @@ var _ = Describe("ParseMsgCommands", func() {
 		It("should parse tieredrewards.MsgClaimTierRewards command in the transaction", func() {
 			block, _ := mustParseBlockResp(usecase_parser_test.TX_MSG_TIER_BLOCK_RESP)
 			blockResults := mustParseBlockResultsResp(
-				usecase_parser_test.TX_MSG_TIER_BLOCK_RESULTS_RESP,
+				usecase_parser_test.TX_MSG_TIER_CLAIM_TIER_REWARDS_BLOCK_RESULTS_RESP,
 				&tendermint.Base64BlockResultEventAttributeDecoder{},
 			)
 			tx := MustParseTxsResp(usecase_parser_test.TX_MSG_TIER_CLAIM_TIER_REWARDS_TXS_RESP)
@@ -47,6 +47,8 @@ var _ = Describe("ParseMsgCommands", func() {
 							Owner:       "cro1dulwqgcdpemn8c34sjd92fxepz5p0sqpeevw84",
 							PositionIds: []string{"1", "2", "3"},
 						},
+						BaseRewards:  "1000basecro",
+						BonusRewards: "500basecro",
 					},
 				),
 			}))

--- a/usecase/parser/test/tx_msg_tier_claim_tier_rewards.go
+++ b/usecase/parser/test/tx_msg_tier_claim_tier_rewards.go
@@ -57,3 +57,83 @@ const TX_MSG_TIER_CLAIM_TIER_REWARDS_TXS_RESP = `{
     "events": []
   }
 }`
+
+const TX_MSG_TIER_CLAIM_TIER_REWARDS_BLOCK_RESULTS_RESP = `{
+  "jsonrpc": "2.0",
+  "id": -1,
+  "result": {
+    "height": "100000",
+    "txs_results": [
+      {
+        "code": 0,
+        "data": "",
+        "log": "[]",
+        "info": "",
+        "gas_wanted": "200000",
+        "gas_used": "100000",
+        "events": [
+          {
+            "type": "message",
+            "attributes": [
+              {
+                "key": "YWN0aW9u",
+                "value": "dGllcg==",
+                "index": false
+              }
+            ]
+          },
+          {
+            "type": "chainmain.tieredrewards.v1.EventTierRewardsClaimed",
+            "attributes": [
+              {
+                "key": "bXNnX2luZGV4",
+                "value": "MA==",
+                "index": false
+              },
+              {
+                "key": "b3duZXI=",
+                "value": "Y3JvMWR1bHdxZ2NkcGVtbjhjMzRzamQ5MmZ4ZXB6NXAwc3FwZWV2dzg0",
+                "index": false
+              },
+              {
+                "key": "cG9zaXRpb25faWRz",
+                "value": "MSwyLDM=",
+                "index": false
+              },
+              {
+                "key": "YmFzZV9yZXdhcmRz",
+                "value": "MTAwMGJhc2Vjcm8=",
+                "index": false
+              },
+              {
+                "key": "Ym9udXNfcmV3YXJkcw==",
+                "value": "NTAwYmFzZWNybw==",
+                "index": false
+              }
+            ]
+          }
+        ],
+        "codespace": ""
+      }
+    ],
+    "begin_block_events": [],
+    "end_block_events": [],
+    "validator_updates": null,
+    "consensus_param_updates": {
+      "block": {
+        "max_bytes": "1048576",
+        "max_gas": "81500000"
+      },
+      "evidence": {
+        "max_age_num_blocks": "100000",
+        "max_age_duration": "172800000000000",
+        "max_bytes": "1048576"
+      },
+      "validator": {
+        "pub_key_types": [
+          "ed25519"
+        ]
+      }
+    }
+  }
+}`

--- a/usecase/parser/test/tx_msg_tier_withdraw_from_tier.go
+++ b/usecase/parser/test/tx_msg_tier_withdraw_from_tier.go
@@ -54,6 +54,27 @@ const TX_MSG_TIER_WITHDRAW_FROM_TIER_TXS_RESP = `{
       "signatures": []
     },
     "timestamp": "2024-06-15T10:00:00Z",
-    "events": []
+    "events": [
+      {
+        "type": "chainmain.tieredrewards.v1.EventPositionWithdrawn",
+        "attributes": [
+            {
+                "key": "amount",
+                "value": "{\"denom\":\"basetcro\",\"amount\":\"1000000000\"}",
+                "index": true
+            },
+            {
+                "key": "position",
+                "value": "{\"id\":\"272\",\"owner\":\"tcro1vzgslnayeum4t6qt7j2cm79nrppaw4w4se038w\",\"tier_id\":3,\"amount\":\"1000000000\",\"validator\":\"\",\"delegated_shares\":\"0.000000000000000000\",\"base_rewards_per_share\":[],\"last_bonus_accrual\":\"0001-01-01T00:00:00Z\",\"exit_triggered_at\":\"2026-04-28T10:07:43.510505520Z\",\"exit_unlock_at\":\"2026-04-28T10:11:43.510505520Z\",\"created_at_height\":\"27374591\",\"created_at_time\":\"2026-04-28T10:03:12.278738851Z\",\"last_event_seq\":\"0\",\"last_known_bonded\":false}",
+                "index": true
+            },
+            {
+                "key": "msg_index",
+                "value": "0",
+                "index": true
+            }
+        ]
+      }
+    ]
   }
 }`

--- a/usecase/parser/utils/utils.go
+++ b/usecase/parser/utils/utils.go
@@ -1,0 +1,11 @@
+package utils
+
+import "strconv"
+
+func UnquoteOrRaw(s string) string {
+	unquoted, err := strconv.Unquote(s)
+	if err != nil {
+		return s
+	}
+	return unquoted
+}


### PR DESCRIPTION
new fields on msg:
- MsgLockTier: positionId (string)
- MsgCommitDelegationToTier: positionId (string)
- MsgAddToTierPosition: positionId (string)
- MsgRedelegate: completionTime, positionId, unbondingId (string)
- MsgUndelegate: completionTime, positionId, unbondingId (string)
- MsgTriggerExitFromTier: exitUnlockAt, positionId (string)
- MsgClearPosition: positionId (string)
- MsgWithdrawFromTier: amount (string)
- MsgClaimTierRewards: baseRewards, bonusRewards (string)
- MsgExitTierWithDelegation: positionId, transferredAmount, transferredShares (string), fullExit (bool)